### PR TITLE
Fix warning

### DIFF
--- a/rpd_tracer/rpd_tracer.cpp
+++ b/rpd_tracer/rpd_tracer.cpp
@@ -446,7 +446,7 @@ void rpdInit()
 {
     //printf("rpd_tracer, because\n");
 
-    char *filename = getenv("RPDT_FILENAME");
+    const char *filename = getenv("RPDT_FILENAME");
     if (filename == NULL)
         filename = "./trace.rpd";
 


### PR DESCRIPTION
ISO C++11 does not allow conversion from string literal to 'char *'