### PR TITLE
Add Inline Flushing

### DIFF
--- a/rpd_tracer/ApiTable.cpp
+++ b/rpd_tracer/ApiTable.cpp
@@ -39,9 +39,6 @@ public:
     static const int BUFFERSIZE = 4096 * 16;
     static const int BATCHSIZE = 4096;           // rows per transaction
     std::array<ApiTable::row, BUFFERSIZE> rows; // Circular buffer
-    int head;
-    int tail;
-    int count;
 
     std::map<std::pair<sqlite3_int64, sqlite3_int64>, std::deque<ApiTable::row>> roctxStacks;
 

--- a/rpd_tracer/BufferedTable.cpp
+++ b/rpd_tracer/BufferedTable.cpp
@@ -47,7 +47,8 @@ void BufferedTable::flush()
         m_wait.wait(lock);
 
     // Worker paused, clear the buffer ourselves
-    while (m_head > m_tail) {
+    auto flushPoint = m_head;
+    while (flushPoint > m_tail) {
         lock.unlock();
         writeRows();
         lock.lock();

--- a/rpd_tracer/BufferedTable.cpp
+++ b/rpd_tracer/BufferedTable.cpp
@@ -1,0 +1,97 @@
+/**************************************************************************
+ * Copyright (c) 2023 Advanced Micro Devices, Inc.
+ **************************************************************************/
+#include "Table.h"
+#include "Utility.h"
+
+#include <thread>
+
+
+class BufferedTablePrivate
+{
+public:
+    BufferedTablePrivate(BufferedTable *cls) : p(cls) {}
+
+    void work();                // work thread
+    std::thread *worker;
+    bool done;
+    bool workerRunning;
+
+    BufferedTable *p;
+};
+
+BufferedTable::BufferedTable(const char *basefile, int bufferSize, int batchsize)
+: Table(basefile)
+, BUFFERSIZE(bufferSize)
+, BATCHSIZE(batchsize)
+, d(new BufferedTablePrivate(this))
+{
+    d->done = false;
+    d->workerRunning = true;
+    d->worker = new std::thread(&BufferedTablePrivate::work, d);
+}
+
+BufferedTable::~BufferedTable()
+{
+    delete d;
+    // finalize here?  Possibly a second time
+}
+
+
+void BufferedTable::flush()
+{
+    std::unique_lock<std::mutex> lock(m_mutex);
+
+    // wait for worker to pause
+    while (d->workerRunning == true)
+        m_wait.wait(lock);
+
+    // Worker paused, clear the buffer ourselves
+    while (m_head > m_tail) {
+        lock.unlock();
+        writeRows();
+        lock.lock();
+    }
+
+    // Table specific flush
+    flushRows();	// While holding m_mutex
+}
+
+
+void BufferedTable::finalize()
+{
+    std::unique_lock<std::mutex> lock(m_mutex);
+    d->done = true;
+    m_wait.notify_one();
+    lock.unlock();
+    d->worker->join();
+    d->workerRunning = false;
+    delete d->worker;
+
+    flush();
+}
+
+
+bool BufferedTable::workerRunning()
+{
+    return d->workerRunning;
+}
+
+void BufferedTablePrivate::work()
+{
+    std::unique_lock<std::mutex> lock(p->m_mutex);
+
+    while (done == false) {
+        while ((p->m_head - p->m_tail) >= p->BATCHSIZE) {
+            lock.unlock();
+            p->writeRows();
+            p->m_wait.notify_all();
+            lock.lock();
+        }
+        workerRunning = false;
+        if (done == false)
+            p->m_wait.wait(lock);
+        workerRunning = true;
+    }
+}
+

--- a/rpd_tracer/CopyApiTable.cpp
+++ b/rpd_tracer/CopyApiTable.cpp
@@ -36,25 +36,15 @@ public:
     static const int BUFFERSIZE = 4096 * 4;
     static const int BATCHSIZE = 4096;           // rows per transaction
     std::array<CopyApiTable::row, BUFFERSIZE> rows; // Circular buffer
-    int head;
-    int tail;
-    int count;
 
     sqlite3_stmt *apiInsert;
-
-    void writeRows();
-
-    void work();		// work thread
-    std::thread *worker;
-    bool workerRunning;
-    bool done;
 
     CopyApiTable *p;
 };
 
 
 CopyApiTable::CopyApiTable(const char *basefile)
-: Table(basefile)
+: BufferedTable(basefile, CopyApiTablePrivate::BUFFERSIZE, CopyApiTablePrivate::BATCHSIZE)
 , d(new CopyApiTablePrivate(this))
 {
     int ret;
@@ -63,134 +53,105 @@ CopyApiTable::CopyApiTable(const char *basefile)
 
     // prepare queries to insert row
     ret = sqlite3_prepare_v2(m_connection, "insert into temp_rocpd_copyapi(api_ptr_id, stream, size, width, height, kind, src, dst, srcDevice, dstDevice, sync, pinned) values (?,?,?,?,?,?,?,?,?,?,?,?)", -1, &d->apiInsert, NULL);
-    
-    d->head = 0;    // last produced by insert()
-    d->tail = 0;    // last consumed by 
-
-    d->worker = NULL;
-    d->done = false;
-    d->workerRunning = true;
-
-    d->worker = new std::thread(&CopyApiTablePrivate::work, d);
 }
+
+
+CopyApiTable::~CopyApiTable()
+{
+    delete d;
+}
+
 
 void CopyApiTable::insert(const CopyApiTable::row &row)
 {
     std::unique_lock<std::mutex> lock(m_mutex);
-    while (d->head - d->tail >= CopyApiTablePrivate::BUFFERSIZE) {
+    while (m_head - m_tail >= CopyApiTablePrivate::BUFFERSIZE) {
         // buffer is full; insert in-line or wait
         m_wait.notify_one();  // make sure working is running
         m_wait.wait(lock);
     }
 
-    d->rows[(++d->head) % CopyApiTablePrivate::BUFFERSIZE] = row;
+    d->rows[(++m_head) % CopyApiTablePrivate::BUFFERSIZE] = row;
 
-    if (d->workerRunning == false && (d->head - d->tail) >= CopyApiTablePrivate::BATCHSIZE) {
+    if (workerRunning() == false && (m_head - m_tail) >= CopyApiTablePrivate::BATCHSIZE) {
         lock.unlock();
         m_wait.notify_one();
     }
 }
 
-void CopyApiTable::flush()
-{
-    while (d->head > d->tail)
-        d->writeRows();
-}
 
-void CopyApiTable::finalize()
+void CopyApiTable::flushRows()
 {
-    std::unique_lock<std::mutex> lock(m_mutex);
-    d->done = true;
-    m_wait.notify_one();
-    lock.unlock();
-    d->worker->join();
-    delete d->worker;
-    flush();
     int ret = 0;
+    ret = sqlite3_exec(m_connection, "begin transaction", NULL, NULL, NULL);
     ret = sqlite3_exec(m_connection, "insert into rocpd_copyapi select * from temp_rocpd_copyapi", NULL, NULL, NULL);
     fprintf(stderr, "rocpd_copyapi: %d\n", ret);
+    ret = sqlite3_exec(m_connection, "delete from temp_rocpd_copyapi", NULL, NULL, NULL);
+    ret = sqlite3_exec(m_connection, "commit", NULL, NULL, NULL);
 }
 
 
-void CopyApiTablePrivate::writeRows()
+void CopyApiTable::writeRows()
 {
-    std::unique_lock<std::mutex> lock(p->m_mutex);
+    std::unique_lock<std::mutex> wlock(m_writeMutex);
+    std::unique_lock<std::mutex> lock(m_mutex);
 
-    if (head == tail)
+    if (m_head == m_tail)
         return;
 
     //const timestamp_t cb_begin_time = util::HsaTimer::clocktime_ns(util::HsaTimer::TIME_ID_CLOCK_MONOTONIC);
     // FIXME
     const timestamp_t cb_begin_time = clocktime_ns();
 
-    int start = tail + 1;
-    int end = tail + BATCHSIZE;
-    end = (end > head) ? head : end;
+    int start = m_tail + 1;
+    int end = m_tail + BATCHSIZE;
+    end = (end > m_head) ? m_head : end;
     lock.unlock();
 
-    sqlite3_exec(p->m_connection, "BEGIN DEFERRED TRANSACTION", NULL, NULL, NULL);
+    sqlite3_exec(m_connection, "BEGIN DEFERRED TRANSACTION", NULL, NULL, NULL);
 
     for (int i = start; i <= end; ++i) {
         int index = 1;
-        CopyApiTable::row &r = rows[i % BUFFERSIZE];
+        CopyApiTable::row &r = d->rows[i % BUFFERSIZE];
 
-        sqlite3_bind_int64(apiInsert, index++, r.api_id + p->m_idOffset);
-        sqlite3_bind_text(apiInsert, index++, r.stream.c_str(), -1, SQLITE_STATIC);
+        sqlite3_bind_int64(d->apiInsert, index++, r.api_id + m_idOffset);
+        sqlite3_bind_text(d->apiInsert, index++, r.stream.c_str(), -1, SQLITE_STATIC);
         if (r.size > 0)
-            sqlite3_bind_int(apiInsert, index++, r.size);
+            sqlite3_bind_int(d->apiInsert, index++, r.size);
         else
             //sqlite3_bind_null(apiInsert, index++);
-            sqlite3_bind_text(apiInsert, index++, "", -1, SQLITE_STATIC);
+            sqlite3_bind_text(d->apiInsert, index++, "", -1, SQLITE_STATIC);
         if (r.width > 0)
-            sqlite3_bind_int(apiInsert, index++, r.width);
+            sqlite3_bind_int(d->apiInsert, index++, r.width);
         else
             //sqlite3_bind_null(apiInsert, index++);
-            sqlite3_bind_text(apiInsert, index++, "", -1, SQLITE_STATIC);
+            sqlite3_bind_text(d->apiInsert, index++, "", -1, SQLITE_STATIC);
         if (r.height > 0)
-            sqlite3_bind_int(apiInsert, index++, r.height);
+            sqlite3_bind_int(d->apiInsert, index++, r.height);
         else
             //sqlite3_bind_null(apiInsert, index++);
-            sqlite3_bind_text(apiInsert, index++, "", -1, SQLITE_STATIC);
+            sqlite3_bind_text(d->apiInsert, index++, "", -1, SQLITE_STATIC);
         //sqlite3_bind_text(apiInsert, index++, "", -1, SQLITE_STATIC);
-        sqlite3_bind_int(apiInsert, index++, r.kind);
-        sqlite3_bind_text(apiInsert, index++, r.dst.c_str(), -1, SQLITE_STATIC);
-        sqlite3_bind_text(apiInsert, index++, r.src.c_str(), -1, SQLITE_STATIC);
-        sqlite3_bind_int(apiInsert, index++, r.dstDevice);
-        sqlite3_bind_int(apiInsert, index++, r.srcDevice);
-        sqlite3_bind_int(apiInsert, index++, r.sync);
-        sqlite3_bind_int(apiInsert, index++, r.pinned);
-        int ret = sqlite3_step(apiInsert);
-        sqlite3_reset(apiInsert);
+        sqlite3_bind_int(d->apiInsert, index++, r.kind);
+        sqlite3_bind_text(d->apiInsert, index++, r.dst.c_str(), -1, SQLITE_STATIC);
+        sqlite3_bind_text(d->apiInsert, index++, r.src.c_str(), -1, SQLITE_STATIC);
+        sqlite3_bind_int(d->apiInsert, index++, r.dstDevice);
+        sqlite3_bind_int(d->apiInsert, index++, r.srcDevice);
+        sqlite3_bind_int(d->apiInsert, index++, r.sync);
+        sqlite3_bind_int(d->apiInsert, index++, r.pinned);
+        int ret = sqlite3_step(d->apiInsert);
+        sqlite3_reset(d->apiInsert);
     }
     lock.lock();
-    tail = end;
+    m_tail = end;
     lock.unlock();
 
     //const timestamp_t cb_mid_time = util::HsaTimer::clocktime_ns(util::HsaTimer::TIME_ID_CLOCK_MONOTONIC);
-    sqlite3_exec(p->m_connection, "END TRANSACTION", NULL, NULL, NULL);
+    sqlite3_exec(m_connection, "END TRANSACTION", NULL, NULL, NULL);
     //const timestamp_t cb_end_time = util::HsaTimer::clocktime_ns(util::HsaTimer::TIME_ID_CLOCK_MONOTONIC);
     // FIXME
     const timestamp_t cb_end_time = clocktime_ns();
     char buff[4096];
-    std::snprintf(buff, 4096, "count=%d | remaining=%d", end - start + 1, head - tail);
+    std::snprintf(buff, 4096, "count=%d | remaining=%d", end - start + 1, m_head - m_tail);
     createOverheadRecord(cb_begin_time, cb_end_time, "CopyApiTable::writeRows", buff);
-}
-
-
-void CopyApiTablePrivate::work()
-{
-    std::unique_lock<std::mutex> lock(p->m_mutex);
-
-    while (done == false) {
-        while ((head - tail) >= CopyApiTablePrivate::BATCHSIZE) {
-            lock.unlock();
-            writeRows();
-            p->m_wait.notify_all();
-            lock.lock();
-        }
-        workerRunning = false;
-        if (done == false)
-            p->m_wait.wait(lock);
-        workerRunning = true;
-    }
 }

--- a/rpd_tracer/CuptiDataSource.cpp
+++ b/rpd_tracer/CuptiDataSource.cpp
@@ -121,6 +121,11 @@ void CuptiDataSource::stopTracing()
     cuptiActivityDisable(CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL);
 }
 
+void CuptiDataSource::flush()
+{
+    cuptiActivityFlushAll(0);
+}
+
 void CUPTIAPI CuptiDataSource::api_callback(void *userdata, CUpti_CallbackDomain domain, CUpti_CallbackId cbid, const CUpti_CallbackData *cbInfo)
 {
     Logger &logger = Logger::singleton();

--- a/rpd_tracer/CuptiDataSource.h
+++ b/rpd_tracer/CuptiDataSource.h
@@ -44,8 +44,7 @@ public:
     void end() override;
     void startTracing() override;
     void stopTracing() override;
-
-
+    void flush() override;
 
 private:
     CudaApiIdList m_apiList;

--- a/rpd_tracer/DataSource.h
+++ b/rpd_tracer/DataSource.h
@@ -31,4 +31,5 @@ public:
     virtual void end() = 0;
     virtual void startTracing() = 0;
     virtual void stopTracing() = 0;
+    virtual void flush() = 0;
 };

--- a/rpd_tracer/Logger.cpp
+++ b/rpd_tracer/Logger.cpp
@@ -57,6 +57,11 @@ void rpdstop()
 {
     Logger::singleton().rpdstop();
 }
+
+void rpdflush()
+{
+    Logger::singleton().rpdflush();
+}
 }  // extern "C"
 
 // GFH - This mirrors the function in the pre-refactor code.  Allows both code paths to compile.
@@ -106,6 +111,16 @@ void Logger::rpdstop()
     --m_activeCount;
 }
 
+void Logger::rpdflush()
+{
+    std::unique_lock<std::mutex> lock(m_activeMutex);
+    //fprintf(stderr, "rpd_tracer: FLUSH\n");
+    m_stringTable->flush();
+    m_kernelApiTable->flush();
+    m_copyApiTable->flush();
+    m_opTable->flush();
+    m_apiTable->flush();
+}
 
 
 

--- a/rpd_tracer/Logger.cpp
+++ b/rpd_tracer/Logger.cpp
@@ -115,11 +115,20 @@ void Logger::rpdflush()
 {
     std::unique_lock<std::mutex> lock(m_activeMutex);
     //fprintf(stderr, "rpd_tracer: FLUSH\n");
+    const timestamp_t cb_begin_time = clocktime_ns();
+
+    // Have the data sources flush out whatever they have available
+    for (auto it = m_sources.begin(); it != m_sources.end(); ++it)
+            (*it)->flush();
+
     m_stringTable->flush();
     m_kernelApiTable->flush();
     m_copyApiTable->flush();
     m_opTable->flush();
     m_apiTable->flush();
+
+    const timestamp_t cb_end_time = clocktime_ns();
+    createOverheadRecord(cb_begin_time, cb_end_time, "rpdflush", "");
 }
 
 
@@ -202,11 +211,13 @@ void Logger::finalize()
 
         // Flush recorders
         const timestamp_t begin_time = clocktime_ns();
-        m_stringTable->finalize();
         m_opTable->finalize();		// OpTable before subclassOpTables
-        m_apiTable->finalize();
         m_kernelApiTable->finalize();
         m_copyApiTable->finalize();
+        m_writeOverheadRecords = false;	// Don't make any new overhead records (api calls)
+        m_apiTable->finalize();
+        m_stringTable->finalize();	// String table last
+
         const timestamp_t end_time = clocktime_ns();
         fprintf(stderr, "rpd_tracer: finalized in %f ms\n", 1.0 * (end_time - begin_time) / 1000000);
     }
@@ -214,7 +225,8 @@ void Logger::finalize()
 
 void Logger::createOverheadRecord(uint64_t start, uint64_t end, const std::string &name, const std::string &args)
 {
-return;
+    if (m_writeOverheadRecords == false)
+        return;
     ApiTable::row row;
     row.pid = GetPid();
     row.tid = GetTid();

--- a/rpd_tracer/Logger.h
+++ b/rpd_tracer/Logger.h
@@ -72,4 +72,6 @@ private:
 
     void init();
     void finalize();
+
+    bool m_writeOverheadRecords {true};
 };

--- a/rpd_tracer/Logger.h
+++ b/rpd_tracer/Logger.h
@@ -46,6 +46,7 @@ public:
     // External control to stop/stop logging
     void rpdstart();
     void rpdstop();
+    void rpdflush();
 
     // Insert an api event.  Used to log internal state or performance
     void createOverheadRecord(uint64_t start, uint64_t end, const std::string &name, const std::string &args);

--- a/rpd_tracer/Makefile
+++ b/rpd_tracer/Makefile
@@ -1,7 +1,7 @@
 
 PREFIX = /usr/local
 
-HIP_PATH?= $(wildcard /opt/rocm/hip)
+HIP_PATH?= $(wildcard /opt/rocm/)
 CUDA_PATH?= $(wildcard /usr/local/cuda/)
 
 HIPCC=$(HIP_PATH)/bin/hipcc

--- a/rpd_tracer/Makefile
+++ b/rpd_tracer/Makefile
@@ -10,7 +10,7 @@ TARGET=hcc
 
 RPD_LIBS = -lsqlite3 -lfmt
 RPD_INCLUDES =
-RPD_SRCS = Table.cpp OpTable.cpp KernelApiTable.cpp CopyApiTable.cpp ApiTable.cpp StringTable.cpp MetadataTable.cpp ApiIdList.cpp Logger.cpp
+RPD_SRCS = Table.cpp BufferedTable.cpp OpTable.cpp KernelApiTable.cpp CopyApiTable.cpp ApiTable.cpp StringTable.cpp MetadataTable.cpp ApiIdList.cpp Logger.cpp
 
 ifneq (,$(HIP_PATH))
         $(info Building with roctracer)

--- a/rpd_tracer/OpTable.cpp
+++ b/rpd_tracer/OpTable.cpp
@@ -41,27 +41,17 @@ public:
     static const int BATCHSIZE = 4096;           // rows per transaction
     std::array<OpTable::row, BUFFERSIZE> rows; // Circular buffer
     std::map<sqlite3_int64, sqlite3_int64> descriptions;
-    std::mutex m_descriptionLock;
-    int head;
-    int tail;
-    int count;
+    std::mutex descriptionLock;
 
     sqlite3_stmt *opInsert;
     sqlite3_stmt *apiOpInsert;
-
-    void writeRows();
-
-    void work();		// work thread
-    std::thread *worker;
-    bool workerRunning;
-    bool done;
 
     OpTable *p;
 };
 
 
 OpTable::OpTable(const char *basefile)
-: Table(basefile)
+: BufferedTable(basefile, OpTablePrivate::BUFFERSIZE, OpTablePrivate::BATCHSIZE)
 , d(new OpTablePrivate(this))
 {
     int ret;
@@ -72,30 +62,28 @@ OpTable::OpTable(const char *basefile)
     // prepare queries to insert row
     ret = sqlite3_prepare_v2(m_connection, "insert into temp_rocpd_op(id, gpuId, queueId, sequenceId, completionSignal, start, end, description_id, opType_id) values (?,?,?,?,?,?,?,?,?)", -1, &d->opInsert, NULL);
     ret = sqlite3_prepare_v2(m_connection, "insert into temp_rocpd_api_ops(api_id, op_id) values (?,?)", -1, &d->apiOpInsert, NULL);
-    
-    d->head = 0;    // last produced by insert()
-    d->tail = 0;    // last consumed by 
-
-    d->worker = NULL;
-    d->done = false;
-    d->workerRunning = true;
-
-    d->worker = new std::thread(&OpTablePrivate::work, d);
 }
+
+
+OpTable::~OpTable()
+{
+    delete d;
+}
+
 
 void OpTable::insert(const OpTable::row &row)
 {
     std::unique_lock<std::mutex> lock(m_mutex);
-    while (d->head - d->tail >= OpTablePrivate::BUFFERSIZE) {
+    while (m_head - m_tail >= OpTablePrivate::BUFFERSIZE) {
         // buffer is full; insert in-line or wait
         m_wait.notify_one();  // make sure working is running
         m_wait.wait(lock);
     }
 
-    d->rows[(++d->head) % OpTablePrivate::BUFFERSIZE] = row;
+    d->rows[(++m_head) % OpTablePrivate::BUFFERSIZE] = row;
 
-    if (d->workerRunning == false && (d->head - d->tail) >= OpTablePrivate::BATCHSIZE) {
-        lock.unlock();
+    if (workerRunning() == false && (m_head - m_tail) >= OpTablePrivate::BATCHSIZE) {
+        //lock.unlock();
         m_wait.notify_one();
     }
 }
@@ -104,117 +92,90 @@ void OpTable::associateDescription(const sqlite3_int64 &api_id, const sqlite3_in
 {
     // FIXME: double buffer this?
     // writeRows uses this structure heavily, intermittently.  May matter
-    std::lock_guard<std::mutex> guard(d->m_descriptionLock);
+    std::lock_guard<std::mutex> guard(d->descriptionLock);
     d->descriptions[api_id] = string_id;
 }
 
-void OpTable::flush()
+void OpTable::flushRows()
 {
-    while (d->head > d->tail)
-        d->writeRows();
-}
-
-void OpTable::finalize()
-{
-    std::unique_lock<std::mutex> lock(m_mutex);
-    d->done = true;
-    m_wait.notify_one();
-    lock.unlock();
-    d->worker->join();
-    delete d->worker;
-    flush();
     int ret = 0;
+    ret = sqlite3_exec(m_connection, "begin transaction", NULL, NULL, NULL);
     ret = sqlite3_exec(m_connection, "insert into rocpd_op select * from temp_rocpd_op", NULL, NULL, NULL);
     fprintf(stderr, "rocpd_op: %d\n", ret);
     ret = sqlite3_exec(m_connection, "insert into rocpd_api_ops (api_id, op_id) select api_id, op_id from temp_rocpd_api_ops", NULL, NULL, NULL);
     fprintf(stderr, "rocpd_api_ops: %d\n", ret);
+    ret = sqlite3_exec(m_connection, "delete from temp_rocpd_op", NULL, NULL, NULL);
+    ret = sqlite3_exec(m_connection, "delete from temp_rocpd_api_ops", NULL, NULL, NULL);
+    ret = sqlite3_exec(m_connection, "commit", NULL, NULL, NULL);
 }
 
 
-void OpTablePrivate::writeRows()
+void OpTable::writeRows()
 {
-    std::unique_lock<std::mutex> lock(p->m_mutex);
+    std::unique_lock<std::mutex> wlock(m_writeMutex);
+    std::unique_lock<std::mutex> lock(m_mutex);
 
-    if (head == tail)
+    if (m_head == m_tail)
         return;
 
     // FIXME
     //const timestamp_t cb_begin_time = util::HsaTimer::clocktime_ns(util::HsaTimer::TIME_ID_CLOCK_MONOTONIC);
     const timestamp_t cb_begin_time = clocktime_ns();
 
-    int start = tail + 1;
-    int end = tail + BATCHSIZE;
-    end = (end > head) ? head : end;
+    int start = m_tail + 1;
+    int end = m_tail + BATCHSIZE;
+    end = (end > m_head) ? m_head : end;
     lock.unlock();
 
-    sqlite3_exec(p->m_connection, "BEGIN DEFERRED TRANSACTION", NULL, NULL, NULL);
+    sqlite3_exec(m_connection, "BEGIN DEFERRED TRANSACTION", NULL, NULL, NULL);
 
     for (int i = start; i <= end; ++i) {
         // insert rocpd_op
         int index = 1;
-        OpTable::row &r = rows[i % BUFFERSIZE];
-        sqlite3_int64 primaryKey = i + p->m_idOffset;
+        OpTable::row &r = d->rows[i % BUFFERSIZE];
+        sqlite3_int64 primaryKey = i + m_idOffset;
 
         // check for description override
 #if 1
         {
-            std::lock_guard<std::mutex> guard(m_descriptionLock);
-            auto it = descriptions.find(r.api_id);
-            if (it != descriptions.end()) {
+            std::lock_guard<std::mutex> guard(d->descriptionLock);
+            auto it = d->descriptions.find(r.api_id);
+            if (it != d->descriptions.end()) {
                 r.description_id = it->second;
-                descriptions.erase(it);
+                d->descriptions.erase(it);
             }
         }
 #endif
-        sqlite3_bind_int64(opInsert, index++, primaryKey);
-        sqlite3_bind_int(opInsert, index++, r.gpuId);
-        sqlite3_bind_int(opInsert, index++, r.queueId);
-        sqlite3_bind_int(opInsert, index++, r.sequenceId);
-        sqlite3_bind_text(opInsert, index++, "", -1, SQLITE_STATIC);
-        sqlite3_bind_int64(opInsert, index++, r.start);
-        sqlite3_bind_int64(opInsert, index++, r.end);
-        sqlite3_bind_int64(opInsert, index++, r.description_id + p->m_idOffset);
-        sqlite3_bind_int64(opInsert, index++, r.opType_id + p->m_idOffset);
-        int ret = sqlite3_step(opInsert);
-        sqlite3_reset(opInsert);
+        sqlite3_bind_int64(d->opInsert, index++, primaryKey);
+        sqlite3_bind_int(d->opInsert, index++, r.gpuId);
+        sqlite3_bind_int(d->opInsert, index++, r.queueId);
+        sqlite3_bind_int(d->opInsert, index++, r.sequenceId);
+        sqlite3_bind_text(d->opInsert, index++, "", -1, SQLITE_STATIC);
+        sqlite3_bind_int64(d->opInsert, index++, r.start);
+        sqlite3_bind_int64(d->opInsert, index++, r.end);
+        sqlite3_bind_int64(d->opInsert, index++, r.description_id + m_idOffset);
+        sqlite3_bind_int64(d->opInsert, index++, r.opType_id + m_idOffset);
+        int ret = sqlite3_step(d->opInsert);
+        sqlite3_reset(d->opInsert);
 
         // Insert rocpd_api_ops
-        //sqlite_int64 rowId = sqlite3_last_insert_rowid(p->m_connection);
+        //sqlite_int64 rowId = sqlite3_last_insert_rowid(m_connection);
         index = 1;
-        sqlite3_bind_int64(apiOpInsert, index++, sqlite3_int64(r.api_id) + p->m_idOffset);
-        sqlite3_bind_int64(apiOpInsert, index++, sqlite3_int64(i) + p->m_idOffset);
-        ret = sqlite3_step(apiOpInsert);
-        sqlite3_reset(apiOpInsert);
+        sqlite3_bind_int64(d->apiOpInsert, index++, sqlite3_int64(r.api_id) + m_idOffset);
+        sqlite3_bind_int64(d->apiOpInsert, index++, sqlite3_int64(i) + m_idOffset);
+        ret = sqlite3_step(d->apiOpInsert);
+        sqlite3_reset(d->apiOpInsert);
     }
     lock.lock();
-    tail = end;
+    m_tail = end;
     lock.unlock();
 
     //const timestamp_t cb_mid_time = util::HsaTimer::clocktime_ns(util::HsaTimer::TIME_ID_CLOCK_MONOTONIC);
-    sqlite3_exec(p->m_connection, "END TRANSACTION", NULL, NULL, NULL);
+    sqlite3_exec(m_connection, "END TRANSACTION", NULL, NULL, NULL);
     // FIXME
     //const timestamp_t cb_end_time = util::HsaTimer::clocktime_ns(util::HsaTimer::TIME_ID_CLOCK_MONOTONIC);
     const timestamp_t cb_end_time = clocktime_ns() + 1;
     char buff[4096];
-    std::snprintf(buff, 4096, "count=%d | remaining=%d", end - start + 1, head - tail);
+    std::snprintf(buff, 4096, "count=%d | remaining=%d", end - start + 1, m_head - m_tail);
     createOverheadRecord(cb_begin_time, cb_end_time, "OpTable::writeRows", buff);
-}
-
-
-void OpTablePrivate::work()
-{
-    std::unique_lock<std::mutex> lock(p->m_mutex);
-
-    while (done == false) {
-        while ((head - tail) >= OpTablePrivate::BATCHSIZE) {
-            lock.unlock();
-            writeRows();
-            p->m_wait.notify_all();
-            lock.lock();
-        }
-        workerRunning = false;
-        if (done == false)
-            p->m_wait.wait(lock);
-        workerRunning = true;
-    }
 }

--- a/rpd_tracer/RoctracerDataSource.cpp
+++ b/rpd_tracer/RoctracerDataSource.cpp
@@ -898,6 +898,11 @@ void RoctracerDataSource::stopTracing() {
     roctracer_stop();
 }
 
+void RoctracerDataSource::flush() {
+    roctracer_flush_activity();
+    roctracer_flush_activity_expl(m_hccPool);
+}
+
 void RoctracerDataSource::end() {
     roctracer_stop();
     roctracer_disable_domain_callback(ACTIVITY_DOMAIN_HIP_API);

--- a/rpd_tracer/RoctracerDataSource.h
+++ b/rpd_tracer/RoctracerDataSource.h
@@ -42,6 +42,7 @@ public:
     void end() override;
     void startTracing() override;
     void stopTracing() override;
+    void flush() override;
 
 private:
     RocmApiIdList m_apiList;

--- a/rpd_tracer/StringTable.cpp
+++ b/rpd_tracer/StringTable.cpp
@@ -103,7 +103,7 @@ void StringTablePrivate::insert(StringTable::row &row)
 	//FIXME
         const timestamp_t end = clocktime_ns();
         lock.unlock();
-        createOverheadRecord(start, end, "BLOCKING", "rpd_tracer::StringTable::insert");
+        //createOverheadRecord(start, end, "BLOCKING", "rpd_tracer::StringTable::insert");
         lock.lock();
     }
 

--- a/rpd_tracer/Table.h
+++ b/rpd_tracer/Table.h
@@ -11,7 +11,7 @@ class Table
 {
 public:
     Table(const char *basefile);
-    ~Table();
+    virtual ~Table();
     
     virtual void flush() = 0;
     virtual void finalize() = 0;
@@ -21,16 +21,47 @@ public:
 protected:
     sqlite3 *m_connection;
     std::mutex m_mutex;
+    //std::mutex m_writeMutex;
     std::condition_variable m_wait;
     sqlite3_int64 m_idOffset;
 };
 
+class BufferedTablePrivate;
+class BufferedTable: public Table
+{
+public:
+    void flush() override;
+    void finalize() override;
+
+protected:
+    BufferedTablePrivate *d;
+    friend class BufferedTablePrivate;
+
+    BufferedTable(const char *basefile, int bufferSize, int batchsize);
+    virtual ~BufferedTable();
+
+    std::mutex m_mutex;
+    std::mutex m_writeMutex;
+    std::condition_variable m_wait;
+
+    const int BUFFERSIZE;
+    const int BATCHSIZE;
+    int m_head {0};
+    int m_tail {0};
+
+    bool workerRunning();
+
+    virtual void writeRows() = 0;	// "write" to buffers (cache db)
+    virtual void flushRows() = 0;	// "flush" to disk (main db)
+};
+
 
 class StringTablePrivate;
-class StringTable: public Table
+class StringTable: public BufferedTable
 {
 public:
     StringTable(const char *basefile);
+    virtual ~StringTable();
 
     struct row {
         std::string string;
@@ -39,20 +70,22 @@ public:
 
     //void insert(const row&);
     sqlite3_int64 getOrCreate(const std::string&);
-    void flush();
-    void finalize();
 
 private:
     StringTablePrivate *d;
     friend class StringTablePrivate;
+
+    virtual void writeRows() override;
+    virtual void flushRows() override;
 };
 
 
 class ApiTablePrivate;
-class ApiTable: public Table
+class ApiTable: public BufferedTable
 {
 public:
     ApiTable(const char *basefile);
+    virtual ~ApiTable();
 
     struct row {
         int pid;
@@ -70,20 +103,22 @@ public:
     void popRoctx(const row&);
     void suspendRoctx(sqlite3_int64 atTime);
     void resumeRoctx(sqlite3_int64 atTime);
-    void flush();
-    void finalize();
 
 private:
     ApiTablePrivate *d;
     friend class ApiTablePrivate;
+
+    virtual void writeRows() override;
+    virtual void flushRows() override;
 };
 
 
 class KernelApiTablePrivate;
-class KernelApiTable: public Table
+class KernelApiTable: public BufferedTable
 {
 public:
     KernelApiTable(const char *basefile);
+    virtual ~KernelApiTable();
 
     struct row {
         std::string stream;
@@ -104,20 +139,22 @@ public:
     };
 
     void insert(const row&);
-    void flush();
-    void finalize();
 
 private:
     KernelApiTablePrivate *d;
     friend class KernelApiTablePrivate;
+
+    virtual void writeRows() override;
+    virtual void flushRows() override;
 };
 
 
 class CopyApiTablePrivate;
-class CopyApiTable: public Table
+class CopyApiTable: public BufferedTable
 {
 public:
     CopyApiTable(const char *basefile);
+    virtual ~CopyApiTable();
 
     struct row {
         std::string stream;
@@ -134,12 +171,13 @@ public:
         sqlite3_int64 api_id {0};   // Baseclass ApiTable primary key (correlation id)
     };
     void insert(const row&);
-    void flush();
-    void finalize();
 
 private:
     CopyApiTablePrivate *d;
     friend class CopyApiTablePrivate;
+
+    virtual void writeRows() override;
+    virtual void flushRows() override;
 };
 
 
@@ -168,10 +206,11 @@ private:
 
 
 class OpTablePrivate;
-class OpTable: public Table
+class OpTable: public BufferedTable
 {
 public:
     OpTable(const char *basefile);
+    virtual ~OpTable();
 
     struct row {
         int gpuId;
@@ -187,12 +226,13 @@ public:
 
     void insert(const row&);
     void associateDescription(const sqlite3_int64 &api_id, const sqlite3_int64 &string_id);
-    void flush();
-    void finalize();
 
 private:
     OpTablePrivate *d;
     friend class OpTablePrivate;
+
+    virtual void writeRows() override;
+    virtual void flushRows() override;
 };
 
 

--- a/rpd_tracer/rpdTracerControl.py
+++ b/rpd_tracer/rpdTracerControl.py
@@ -99,6 +99,9 @@ class rpdTracerControl:
     def stop(self):
         rpdTracerControl.__rpd.rpdstop()
 
+    def flush(self):
+        rpdTracerControl.__rpd.rpdflush()
+
     def __enter__(self):
         self.start()
 


### PR DESCRIPTION
Added inline flushing to work around problems with workload that do not shutdown properly.
Added api to flush mid run.  Added rpdTracerControl method to call api.
Re-enabled the overhead records.