### PR TITLE
Add support for rocprofiler-sdk collection

### DIFF
--- a/rpd_tracer/Logger.cpp
+++ b/rpd_tracer/Logger.cpp
@@ -214,6 +214,7 @@ void Logger::init()
 
     // Create one instance of each available datasource
     std::list<std::string> factories = {
+        "RocprofDataSourceFactory",
         "RoctracerDataSourceFactory",
         "CuptiDataSourceFactory",
         "RocmSmiDataSourceFactory"

--- a/rpd_tracer/Logger.cpp
+++ b/rpd_tracer/Logger.cpp
@@ -215,7 +215,7 @@ void Logger::init()
     // Create one instance of each available datasource
     std::list<std::string> factories = {
         "RocprofDataSourceFactory",
-        "RoctracerDataSourceFactory",
+        //"RoctracerDataSourceFactory",
         "CuptiDataSourceFactory",
         "RocmSmiDataSourceFactory"
         };

--- a/rpd_tracer/Makefile
+++ b/rpd_tracer/Makefile
@@ -14,12 +14,16 @@ RPD_SRCS = Table.cpp BufferedTable.cpp OpTable.cpp KernelApiTable.cpp CopyApiTab
 
 ifneq (,$(HIP_PATH))
         $(info Building with roctracer)
-        #RPD_LIBS += -L/opt/rocm/lib -lroctracer64 -lroctx64 -lamdhip64 -lrocm_smi64
-        RPD_LIBS += -L/opt/rocm/lib -lrocprofiler-sdk #-lroctx64 -lamdhip64 #-lrocprofiler-sdk
-        RPD_INCLUDES += -I/opt/rocm/include -I/opt/rocm/include/roctracer -I/opt/rocm/include/hsa
-        RPD_SRCS += RocprofDataSource.cpp #RoctracerDataSource.cpp #RocmSmiDataSource.cpp
-        RPD_INCLUDES += -I/opt/rocm/share/rocprofiler-sdk/samples
+        RPD_LIBS += -L/opt/rocm/lib
+        RPD_LIBS += -lroctracer64 -lroctx64 -lamdhip64 -lrocm_smi64
+        RPD_LIBS += -lrocprofiler-sdk 
+
+        RPD_SRCS += RoctracerDataSource.cpp #RocmSmiDataSource.cpp
+        RPD_SRCS += RocprofDataSource.cpp
+
         RPD_INCLUDES += -D__HIP_PLATFORM_AMD__
+        RPD_INCLUDES += -I/opt/rocm/include -I/opt/rocm/include/roctracer -I/opt/rocm/include/hsa
+        RPD_INCLUDES += -I/opt/rocm/share/rocprofiler-sdk/samples
 endif
 
 ifneq ($(CUDA_PATH),)

--- a/rpd_tracer/Makefile
+++ b/rpd_tracer/Makefile
@@ -48,7 +48,7 @@ $(RPD_MAIN): $(RPD_OBJS)
 	$(CXX) -o $@ $^ -shared -rdynamic -std=c++11 $(RPD_LIBS) -g
 
 .cpp.o:
-	$(CXX) -o $@ -c $< $(RPD_INCLUDES) -DAMD_INTERNAL_BUILD -std=c++11 -fPIC -g -O3
+	$(CXX) -o $@ -c $< $(RPD_INCLUDES) -DAMD_INTERNAL_BUILD -std=c++17 -fPIC -g -O3
 
 #$(PREFIX)/lib/lib$(RPD_MAIN):
 #	ln -s $(PREFIX)/lib/$(RPD_MAIN) $@

--- a/rpd_tracer/Makefile
+++ b/rpd_tracer/Makefile
@@ -14,9 +14,11 @@ RPD_SRCS = Table.cpp BufferedTable.cpp OpTable.cpp KernelApiTable.cpp CopyApiTab
 
 ifneq (,$(HIP_PATH))
         $(info Building with roctracer)
-        RPD_LIBS += -L/opt/rocm/lib -lroctracer64 -lroctx64 -lamdhip64 -lrocm_smi64
+        #RPD_LIBS += -L/opt/rocm/lib -lroctracer64 -lroctx64 -lamdhip64 -lrocm_smi64
+        RPD_LIBS += -L/opt/rocm/lib -lrocprofiler-sdk #-lroctx64 -lamdhip64 #-lrocprofiler-sdk
         RPD_INCLUDES += -I/opt/rocm/include -I/opt/rocm/include/roctracer -I/opt/rocm/include/hsa
-        RPD_SRCS += RoctracerDataSource.cpp #RocmSmiDataSource.cpp
+        RPD_SRCS += RocprofDataSource.cpp #RoctracerDataSource.cpp #RocmSmiDataSource.cpp
+        RPD_INCLUDES += -I/opt/rocm/share/rocprofiler-sdk/samples
         RPD_INCLUDES += -D__HIP_PLATFORM_AMD__
 endif
 

--- a/rpd_tracer/RocprofDataSource.cpp
+++ b/rpd_tracer/RocprofDataSource.cpp
@@ -1,0 +1,344 @@
+/*********************************************************************************
+* Copyright (c) 2021 - 2023 Advanced Micro Devices, Inc. All rights reserved.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+********************************************************************************/
+#include "RocprofDataSource.h"
+
+#include <rocprofiler-sdk/context.h>
+#include <rocprofiler-sdk/fwd.h>
+#include <rocprofiler-sdk/marker/api_id.h>
+#include <rocprofiler-sdk/registration.h>
+#include <rocprofiler-sdk/rocprofiler.h>
+//#include <rocprofiler-sdk/cxx/name_info.hpp>	// busted
+
+//#include "common/call_stack.hpp"
+//#include "common/defines.hpp"
+//#include "common/filesystem.hpp"
+//#include "common/name_info.hpp"
+
+#include <vector>
+
+#include <sqlite3.h>
+#include <fmt/format.h>
+
+#include "Logger.h"
+#include "Utility.h"
+
+
+// Create a factory for the Logger to locate and use
+extern "C" {
+    DataSource *RocprofDataSourceFactory() { return new RocprofDataSource(); }
+}  // extern "C"
+
+
+namespace
+{
+    rocprofiler_client_id_t *clientId {nullptr};
+    auto cfg = rocprofiler_tool_configure_result_t{sizeof(rocprofiler_tool_configure_result_t),
+                                            &RocprofDataSource::toolInit,
+                                            &RocprofDataSource::toolFinialize,
+                                            nullptr};
+    rocprofiler_context_id_t client_ctx = {0};
+    rocprofiler_buffer_id_t client_buffer = {};
+
+    // Manage kernel names - #betterThanRoctracer
+    using kernel_symbol_data_t = rocprofiler_callback_tracing_code_object_kernel_symbol_register_data_t;
+    using kernel_symbol_map_t = std::unordered_map<rocprofiler_kernel_id_t, kernel_symbol_data_t>;
+    using kernel_name_map_t = std::unordered_map<rocprofiler_kernel_id_t, const char *>;
+    kernel_symbol_map_t kernel_info = {};
+    kernel_name_map_t kernel_names = {};
+
+    // Manage buffer name - #betterThanRoctracer
+    //using common::buffer_name_info;
+    //buffer_name_info name_info = {};
+
+} // namespace
+
+
+
+
+
+void RocprofDataSource::init()
+{
+    fprintf(stderr, "RocprofDataSource::init\n");
+    stopTracing();
+}
+
+void RocprofDataSource::end() 
+{
+    fprintf(stderr, "RocprofDataSource::end\n");
+    flush();
+}
+
+void RocprofDataSource::startTracing()
+{
+    fprintf(stderr, "RocprofDataSource::startTracing\n");
+    if (client_ctx.handle != 0)
+        rocprofiler_start_context(client_ctx);
+
+}
+
+void RocprofDataSource::stopTracing()
+{
+    fprintf(stderr, "RocprofDataSource::stopTracing\n");
+    if (client_ctx.handle != 0)
+        rocprofiler_stop_context(client_ctx);
+}
+
+void RocprofDataSource::flush()
+{
+    fprintf(stderr, "RocprofDataSource::flush\n");
+    if (clientId != nullptr)
+        rocprofiler_flush_buffer(client_buffer);
+}
+
+void RocprofDataSource::api_callback(rocprofiler_callback_tracing_record_t record, rocprofiler_user_data_t* user_data, void* callback_data)
+{
+    Logger &logger = Logger::singleton();
+
+    if (record.kind == ROCPROFILER_CALLBACK_TRACING_HIP_RUNTIME_API) {
+        thread_local sqlite3_int64 timestamp;	// FIXME: use userdata?  or stack?
+
+        if (record.phase == ROCPROFILER_CALLBACK_PHASE_ENTER) {
+                timestamp = clocktime_ns();
+        }
+        else {	     // ROCPROFILER_CALLBACK_PHASE_EXIT
+            char buff[4096];
+            ApiTable::row row;
+
+            const char *name = fmt::format("{}::{}", record.kind, record.operation).c_str();
+            sqlite3_int64 name_id = logger.stringTable().getOrCreate(name);
+            row.pid = GetPid();
+            row.tid = GetTid();
+            row.start = timestamp;  // From TLS from preceding enter call
+            row.end = clocktime_ns();
+            row.apiName_id = name_id;
+            row.args_id = EMPTY_STRING_ID;
+            row.api_id = record.correlation_id.internal;
+
+#if 0
+            auto info_data_cb = [](rocprofiler_callback_tracing_kind_t,
+                   rocprofiler_tracing_operation_t,
+                   uint32_t          arg_num,
+                   const void* const arg_value_addr,
+                   int32_t           indirection_count,
+                   const char*       arg_type,
+                   const char*       arg_name,
+                   const char*       arg_value_str,
+                   int32_t           dereference_count,
+                   void*             cb_data) -> int {
+                fprintf(stderr, "%d: %s (%s) -> %s\n", arg_num, arg_name, arg_type, arg_value_str);
+                return 0;
+            };
+
+            rocprofiler_iterate_callback_tracing_kind_operation_args(
+                    record, info_data_cb, 2/*max_deref*/, nullptr);
+#endif
+
+            logger.apiTable().insert(row);
+        }
+    } // ROCPROFILER_CALLBACK_TRACING_HIP_RUNTIME_API
+}
+
+void RocprofDataSource::buffer_callback(rocprofiler_context_id_t context, rocprofiler_buffer_id_t buffer_id, rocprofiler_record_header_t** headers, size_t num_headers, void* user_data, uint64_t drop_count)
+{
+    assert(drop_count == 0 && "drop count should be zero for lossless policy");
+
+    fprintf(stderr, "buffer_callback - %ld headers\n", num_headers);
+
+    Logger &logger = Logger::singleton();
+
+    for (size_t i = 0; i < num_headers; ++i) {
+        auto* header = headers[i];
+
+        if (header->category == ROCPROFILER_BUFFER_CATEGORY_TRACING) {
+            if (header->kind == ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH) {
+
+                auto* record = static_cast<rocprofiler_buffer_tracing_kernel_dispatch_record_t*>(header->payload);
+                //sqlite3_int64 name_id = logger.stringTable().getOrCreate(fmt::format("{}::{}", record->kind, record->operation).c_str());
+                // FIXME: op name hack
+                static sqlite3_int64 name_id = logger.stringTable().getOrCreate("KernelExecution");
+                sqlite3_int64 desc_id = logger.stringTable().getOrCreate(kernel_names.at(record->dispatch_info.kernel_id));
+
+                OpTable::row row; 
+                row.gpuId = record->dispatch_info.agent_id.handle;
+                row.queueId = record->dispatch_info.queue_id.handle;
+                row.sequenceId = 0;
+                strncpy(row.completionSignal, "", 18);
+                row.start = record->start_timestamp;
+                row.end = record->end_timestamp;
+                row.description_id = desc_id;
+                row.opType_id = name_id;
+                row.api_id = record->correlation_id.internal;
+
+                logger.opTable().insert(row);
+            }
+            else if (header->kind == ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH) {
+
+                auto *record = static_cast<rocprofiler_buffer_tracing_memory_copy_record_t*>(header->payload);
+                sqlite3_int64 name_id = logger.stringTable().getOrCreate(fmt::format("{}::{}", record->kind, record->operation).c_str());
+                sqlite3_int64 desc_id = logger.stringTable().getOrCreate("");
+
+                OpTable::row row;
+                row.gpuId = record->src_agent_id.handle;
+                row.queueId = record->dst_agent_id.handle;	// FIXME, all wrong
+                row.sequenceId = 0;
+                strncpy(row.completionSignal, "", 18);
+                row.start = record->start_timestamp;
+                row.end = record->end_timestamp;
+                row.description_id = desc_id;
+                row.opType_id = name_id;
+                row.api_id = record->correlation_id.internal;
+
+                logger.opTable().insert(row);
+            }
+        }
+    }
+}
+
+void RocprofDataSource::code_object_callback(rocprofiler_callback_tracing_record_t record, rocprofiler_user_data_t* user_data, void* callback_data)
+{
+    //fprintf(stderr, "code_object_callback\n");
+    if(record.kind == ROCPROFILER_CALLBACK_TRACING_CODE_OBJECT &&
+       record.operation == ROCPROFILER_CODE_OBJECT_LOAD)
+    {
+        if(record.phase == ROCPROFILER_CALLBACK_PHASE_UNLOAD)
+        {
+            // flush the buffer to ensure that any lookups for the client kernel names for the code
+            // object are completed
+            auto flush_status = rocprofiler_flush_buffer(client_buffer);
+            if(flush_status != ROCPROFILER_STATUS_ERROR_BUFFER_BUSY)
+                ;
+        }
+    }
+    else if(record.kind == ROCPROFILER_CALLBACK_TRACING_CODE_OBJECT &&
+            record.operation == ROCPROFILER_CODE_OBJECT_DEVICE_KERNEL_SYMBOL_REGISTER)
+    {
+        auto* data = static_cast<kernel_symbol_data_t*>(record.payload);
+        if (record.phase == ROCPROFILER_CALLBACK_PHASE_LOAD)
+        {
+            kernel_info.emplace(data->kernel_id, *data);
+            kernel_names.emplace(data->kernel_id, cxx_demangle(data->kernel_name));
+        }
+        else if (record.phase == ROCPROFILER_CALLBACK_PHASE_UNLOAD)
+        {
+            kernel_info.erase(data->kernel_id);
+            kernel_names.erase(data->kernel_id);
+        }
+    }
+}
+
+
+// 
+//
+//
+
+extern "C" rocprofiler_tool_configure_result_t*
+rocprofiler_configure(uint32_t                 version,
+                      const char*              runtime_version,
+                      uint32_t                 priority,
+                      rocprofiler_client_id_t* id)
+{
+    fprintf(stderr, "rocprofiler_configure\n");
+    id->name = "rpd_tracer";
+    clientId = id;
+
+    // return pointer to configure data
+    return &cfg;
+}
+
+int RocprofDataSource::toolInit(rocprofiler_client_finalize_t finialize_func, void* tool_data)
+{
+    fprintf(stderr, "RocprofDataSource::toolInit\n");
+
+    //rocprofiler::sdk::get_callback_tracing_names();	// currently busted, compile error in header
+
+    rocprofiler_create_context(&client_ctx);
+
+    rocprofiler_configure_callback_tracing_service(client_ctx,
+                                                   ROCPROFILER_CALLBACK_TRACING_HIP_RUNTIME_API,
+                                                   nullptr,
+                                                   0,
+                                                   api_callback,
+                                                   nullptr);
+                                                   //tool_data);
+
+// Magic stuff
+
+    auto code_object_ops = std::vector<rocprofiler_tracing_operation_t>{
+        ROCPROFILER_CODE_OBJECT_DEVICE_KERNEL_SYMBOL_REGISTER};
+
+    rocprofiler_configure_callback_tracing_service(client_ctx,
+                                                   ROCPROFILER_CALLBACK_TRACING_CODE_OBJECT,
+                                                   code_object_ops.data(),
+                                                   code_object_ops.size(),
+                                                   RocprofDataSource::code_object_callback,
+                                                   nullptr);
+
+    constexpr auto buffer_size_bytes      = 0x40000;
+    constexpr auto buffer_watermark_bytes = buffer_size_bytes / 2;
+
+    rocprofiler_create_buffer(client_ctx,
+                              buffer_size_bytes,
+                              buffer_watermark_bytes,
+                              ROCPROFILER_BUFFER_POLICY_LOSSLESS,
+                              RocprofDataSource::buffer_callback,
+                              nullptr, /*tool_data,*/
+                              &client_buffer);
+
+    rocprofiler_configure_buffer_tracing_service(client_ctx,
+                                                 ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH,
+                                                 nullptr,
+                                                 0,
+                                                 client_buffer);
+
+    rocprofiler_configure_buffer_tracing_service(client_ctx,
+                                                 ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH,
+                                                 nullptr,
+                                                 0,
+                                                 client_buffer);
+
+    auto client_thread = rocprofiler_callback_thread_t{};
+    rocprofiler_create_callback_thread(&client_thread);
+    rocprofiler_assign_callback_thread(client_buffer, client_thread);
+
+    int valid_ctx = 0;
+    rocprofiler_context_is_valid(client_ctx, &valid_ctx);
+    if (valid_ctx == 0) {
+       client_ctx.handle = 0;	// Can't destroy it, so leak it
+       return -1;
+    }
+
+    rocprofiler_start_context(client_ctx);
+    return 0;
+}
+
+void RocprofDataSource::toolFinialize(void* tool_data)
+{
+    // This seems to happen pretty early.  So simulate a shutdown and disable context
+    fprintf(stderr, "RocprofDataSource::toolFinalize\n");
+
+    //end();	// FIXME: singleton - figure out startup order and teardown order
+
+    rocprofiler_stop_context(client_ctx);
+    rocprofiler_flush_buffer(client_buffer);	// hopfully this blocks
+
+    client_ctx.handle = 0;	// save us from ourselves
+}

--- a/rpd_tracer/RocprofDataSource.cpp
+++ b/rpd_tracer/RocprofDataSource.cpp
@@ -33,6 +33,7 @@
 #include "common/name_info.hpp"
 
 #include <vector>
+#include <array>
 
 #include <sqlite3.h>
 #include <fmt/format.h>
@@ -47,71 +48,124 @@ extern "C" {
 }  // extern "C"
 
 
+//
+// The plan:
+//    Shared Class holds data common to all instances (should we ever need more than 1)
+//    Anonymous namespace holds a ptr to the Shared Class.  Not member functio access needed
+//    Class instances have a private object
+//    Contexts have to be generated up-front
+//        One context (always active) to observe code-object loading, etc
+//        Class instances grab a context from an array.  For event callbacks and buffers
+//
+
+class RocprofDataSourceShared;
 namespace
 {
-    rocprofiler_client_id_t *clientId {nullptr};
-    auto cfg = rocprofiler_tool_configure_result_t{sizeof(rocprofiler_tool_configure_result_t),
-                                            &RocprofDataSource::toolInit,
-                                            &RocprofDataSource::toolFinialize,
-                                            nullptr};
-    rocprofiler_context_id_t client_ctx = {0};
-    rocprofiler_buffer_id_t client_buffer = {};
-
-    // Manage kernel names - #betterThanRoctracer
+    RocprofDataSourceShared *s {nullptr};
     using kernel_symbol_data_t = rocprofiler_callback_tracing_code_object_kernel_symbol_register_data_t;
     using kernel_symbol_map_t = std::unordered_map<rocprofiler_kernel_id_t, kernel_symbol_data_t>;
     using kernel_name_map_t = std::unordered_map<rocprofiler_kernel_id_t, const char *>;
+    using common::buffer_name_info;
+    using agent_info_map_t = std::unordered_map<uint64_t, rocprofiler_agent_v0_t>;
+} // namespace
+
+class RocprofDataSourceShared
+{
+public:
+    static RocprofDataSourceShared& singleton();
+
+    rocprofiler_client_id_t *clientId {nullptr};
+    rocprofiler_tool_configure_result_t cfg = rocprofiler_tool_configure_result_t{
+                                            sizeof(rocprofiler_tool_configure_result_t),
+                                            &RocprofDataSource::toolInit,
+                                            &RocprofDataSource::toolFinialize,
+                                            nullptr};
+
+    // Contexts
+    rocprofiler_context_id_t utilityContext = {0};
+    std::array<rocprofiler_context_id_t,1> contexts = {0};
+    size_t nextContext = 0;	// first available context in contexts array
+
+    // Buffers
+    //rocprofiler_buffer_id_t client_buffer = {};
+
+    // Manage kernel names - #betterThanRoctracer
+
     kernel_symbol_map_t kernel_info = {};
     kernel_name_map_t kernel_names = {};
 
     // Manage buffer name - #betterThanRoctracer
-    using common::buffer_name_info;
     buffer_name_info name_info = {};
 
     // Agent info
     // <rocprofiler_profile_config_id_t.handle, rocprofiler_agent_v0_t>
-    using agent_info_map_t = std::unordered_map<uint64_t, rocprofiler_agent_v0_t>;
     agent_info_map_t agents = {};
+private:
+    RocprofDataSourceShared() { s = this; }
+    ~RocprofDataSourceShared() { s = nullptr; }
+};
 
-} // namespace
+RocprofDataSourceShared &RocprofDataSourceShared::singleton()
+{
+    static RocprofDataSourceShared *instance = new RocprofDataSourceShared();	// Leak this
+    return *instance;
+}
 
 
 
+class RocprofDataSourcePrivate
+{
+public:
+    size_t id;
+};
 
+
+RocprofDataSource::RocprofDataSource()
+: d(new RocprofDataSourcePrivate)
+{
+    RocprofDataSourceShared::singleton();	// CRITICAL: static init
+
+    if (s->utilityContext.handle == 0) {
+        // s->contexts have not been created.  Force registration
+        auto ret = rocprofiler_force_configure(nullptr);
+        //fprintf(stderr, "******  rocprofiler_force_configure: %d\n", ret);
+    }
+
+    // assign ourselves then next available id and context
+    assert(s->nextContext < s->contexts.size());
+    d->id = s->nextContext++;
+}
+
+RocprofDataSource::~RocprofDataSource()
+{
+    delete d;
+}
 
 void RocprofDataSource::init()
 {
-    fprintf(stderr, "RocprofDataSource::init\n");
-// FIXME force configure
     stopTracing();
 }
 
 void RocprofDataSource::end() 
 {
-    fprintf(stderr, "RocprofDataSource::end\n");
     flush();
 }
 
 void RocprofDataSource::startTracing()
 {
-    fprintf(stderr, "RocprofDataSource::startTracing\n");
-    if (client_ctx.handle != 0)
-        rocprofiler_start_context(client_ctx);
-
+    assert(s->contexts[d->id].handle != 0);
+    rocprofiler_start_context(s->contexts[d->id]);
 }
 
 void RocprofDataSource::stopTracing()
 {
-    fprintf(stderr, "RocprofDataSource::stopTracing\n");
-    if (client_ctx.handle != 0)
-        rocprofiler_stop_context(client_ctx);
+    assert(s->contexts[d->id].handle != 0);
+    rocprofiler_stop_context(s->contexts[d->id]);
 }
 
 void RocprofDataSource::flush()
 {
-    fprintf(stderr, "RocprofDataSource::flush\n");
-    if (clientId != nullptr)
-        rocprofiler_flush_buffer(client_buffer);
+    // no buffering - no flushing
 }
 
 void RocprofDataSource::api_callback(rocprofiler_callback_tracing_record_t record, rocprofiler_user_data_t* user_data, void* callback_data)
@@ -123,15 +177,15 @@ void RocprofDataSource::api_callback(rocprofiler_callback_tracing_record_t recor
 
         if (record.phase == ROCPROFILER_CALLBACK_PHASE_ENTER) {
                 timestamp = clocktime_ns();
-            //fprintf(stderr, "HIP_RUNTIME_API %d %s\n", record.phase, std::string(name_info[record.kind][record.operation]).c_str());
+            //fprintf(stderr, "HIP_RUNTIME_API %d %s\n", record.phase, std::string(s->name_info[record.kind][record.operation]).c_str());
         }
         else {	     // ROCPROFILER_CALLBACK_PHASE_EXIT
-            //fprintf(stderr, "HIP_RUNTIME_API %d %s %llu\n", record.phase, std::string(name_info[record.kind][record.operation]).c_str(), clocktime_ns() - timestamp);
+            //fprintf(stderr, "HIP_RUNTIME_API %d %s %llu\n", record.phase, std::string(s->name_info[record.kind][record.operation]).c_str(), clocktime_ns() - timestamp);
             char buff[4096];
             ApiTable::row row;
 
             //const char *name = fmt::format("{}::{}", record.kind, record.operation).c_str();
-            sqlite3_int64 name_id = logger.stringTable().getOrCreate(std::string(name_info[record.kind][record.operation]).c_str());
+            sqlite3_int64 name_id = logger.stringTable().getOrCreate(std::string(s->name_info[record.kind][record.operation]).c_str());
             row.pid = GetPid();
             row.tid = GetTid();
             row.start = timestamp;  // From TLS from preceding enter call
@@ -169,7 +223,7 @@ void RocprofDataSource::api_callback(rocprofiler_callback_tracing_record_t recor
             auto &dispatch = *(static_cast<rocprofiler_callback_tracing_kernel_dispatch_data_t*>(record.payload));
             auto &info = dispatch.dispatch_info;
 
-//fprintf(stderr, "%s\n", std::string(name_info[record.kind][record.operation]).c_str());
+//fprintf(stderr, "%s\n", std::string(s->name_info[record.kind][record.operation]).c_str());
 //fprintf(stderr, "%d::%d\n", record.kind, record.operation);
 
             KernelApiTable::row krow;
@@ -183,7 +237,7 @@ void RocprofDataSource::api_callback(rocprofiler_callback_tracing_record_t recor
             krow.workgroupZ = info.workgroup_size.z;
             krow.groupSegmentSize = info.group_segment_size;
             krow.privateSegmentSize = info.private_segment_size;
-            krow.kernelName_id = logger.stringTable().getOrCreate(kernel_names.at(info.kernel_id));
+            krow.kernelName_id = logger.stringTable().getOrCreate(s->kernel_names.at(info.kernel_id));
 
             logger.kernelApiTable().insert(krow);
         }
@@ -195,7 +249,7 @@ void RocprofDataSource::api_callback(rocprofiler_callback_tracing_record_t recor
 
             OpTable::row row;
             //row.gpuId = mapDeviceId(record->device_id);
-            row.gpuId = agents.at(info.agent_id.handle).logical_node_type_id;
+            row.gpuId = s->agents.at(info.agent_id.handle).logical_node_type_id;
             row.queueId = info.queue_id.handle;
             row.sequenceId = 0;
             strncpy(row.completionSignal, "", 18);
@@ -203,7 +257,7 @@ void RocprofDataSource::api_callback(rocprofiler_callback_tracing_record_t recor
             //row.end = record->end_ns + toffset;
             row.start = dispatch.start_timestamp;
             row.end = dispatch.end_timestamp;
-            row.description_id = logger.stringTable().getOrCreate(kernel_names.at(info.kernel_id));
+            row.description_id = logger.stringTable().getOrCreate(s->kernel_names.at(info.kernel_id));
             row.opType_id = name_id;
             row.api_id = record.correlation_id.internal;
 
@@ -219,8 +273,8 @@ void RocprofDataSource::api_callback(rocprofiler_callback_tracing_record_t recor
             crow.api_id = record.correlation_id.internal;       // FIXME, from nested hip call
             crow.size = (uint32_t)(copy.bytes);
             // Use node_id.  Will not match node_type_id from ops.  Can express cpu location
-            crow.dstDevice = agents.at(copy.dst_agent_id.handle).logical_node_id;
-            crow.srcDevice = agents.at(copy.src_agent_id.handle).logical_node_id;
+            crow.dstDevice = s->agents.at(copy.dst_agent_id.handle).logical_node_id;
+            crow.srcDevice = s->agents.at(copy.src_agent_id.handle).logical_node_id;
             crow.kind = EMPTY_STRING_ID;
             crow.sync = true;
 
@@ -248,6 +302,8 @@ void RocprofDataSource::api_callback(rocprofiler_callback_tracing_record_t recor
     }
 }
 
+
+#if 0
 void RocprofDataSource::buffer_callback(rocprofiler_context_id_t context, rocprofiler_buffer_id_t buffer_id, rocprofiler_record_header_t** headers, size_t num_headers, void* user_data, uint64_t drop_count)
 {
     assert(drop_count == 0 && "drop count should be zero for lossless policy");
@@ -263,10 +319,9 @@ void RocprofDataSource::buffer_callback(rocprofiler_context_id_t context, rocpro
             if (header->kind == ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH) {
 
                 auto* record = static_cast<rocprofiler_buffer_tracing_kernel_dispatch_record_t*>(header->payload);
-                //sqlite3_int64 name_id = logger.stringTable().getOrCreate(fmt::format("{}::{}", record->kind, record->operation).c_str());
                 // FIXME: op name hack
                 static sqlite3_int64 name_id = logger.stringTable().getOrCreate("KernelExecution");
-                sqlite3_int64 desc_id = logger.stringTable().getOrCreate(kernel_names.at(record->dispatch_info.kernel_id));
+                sqlite3_int64 desc_id = logger.stringTable().getOrCreate(s->kernel_names.at(record->dispatch_info.kernel_id));
 
                 OpTable::row row; 
                 row.gpuId = record->dispatch_info.agent_id.handle;
@@ -303,6 +358,7 @@ void RocprofDataSource::buffer_callback(rocprofiler_context_id_t context, rocpro
         }
     }
 }
+#endif
 
 void RocprofDataSource::code_object_callback(rocprofiler_callback_tracing_record_t record, rocprofiler_user_data_t* user_data, void* callback_data)
 {
@@ -314,9 +370,10 @@ void RocprofDataSource::code_object_callback(rocprofiler_callback_tracing_record
         {
             // flush the buffer to ensure that any lookups for the client kernel names for the code
             // object are completed
-            auto flush_status = rocprofiler_flush_buffer(client_buffer);
-            if(flush_status != ROCPROFILER_STATUS_ERROR_BUFFER_BUSY)
-                ;
+// FIXME
+            //auto flush_status = rocprofiler_flush_buffer(client_buffer);
+            //if(flush_status != ROCPROFILER_STATUS_ERROR_BUFFER_BUSY)
+            //    ;
         }
     }
     else if(record.kind == ROCPROFILER_CALLBACK_TRACING_CODE_OBJECT &&
@@ -325,35 +382,18 @@ void RocprofDataSource::code_object_callback(rocprofiler_callback_tracing_record
         auto* data = static_cast<kernel_symbol_data_t*>(record.payload);
         if (record.phase == ROCPROFILER_CALLBACK_PHASE_LOAD)
         {
-            kernel_info.emplace(data->kernel_id, *data);
-            kernel_names.emplace(data->kernel_id, cxx_demangle(data->kernel_name));
+            s->kernel_info.emplace(data->kernel_id, *data);
+            s->kernel_names.emplace(data->kernel_id, cxx_demangle(data->kernel_name));
         }
         else if (record.phase == ROCPROFILER_CALLBACK_PHASE_UNLOAD)
         {
-            kernel_info.erase(data->kernel_id);
-            //kernel_names.erase(data->kernel_id);
+            // FIXME: clear these?  At minimum need kernel names at shutdown, async completion
+            //s->kernel_info.erase(data->kernel_id);
+            //s->kernel_names.erase(data->kernel_id);
         }
     }
 }
 
-
-// 
-//
-//
-
-extern "C" rocprofiler_tool_configure_result_t*
-rocprofiler_configure(uint32_t                 version,
-                      const char*              runtime_version,
-                      uint32_t                 priority,
-                      rocprofiler_client_id_t* id)
-{
-    fprintf(stderr, "rocprofiler_configure\n");
-    id->name = "rpd_tracer";
-    clientId = id;
-
-    // return pointer to configure data
-    return &cfg;
-}
 
 std::vector<rocprofiler_agent_v0_t>
 get_gpu_device_agents()
@@ -389,20 +429,75 @@ get_gpu_device_agents()
 }
 
 
+//
+//
+// Static setup
+//
+//
+
+
+extern "C" rocprofiler_tool_configure_result_t*
+rocprofiler_configure(uint32_t                 version,
+                      const char*              runtime_version,
+                      uint32_t                 priority,
+                      rocprofiler_client_id_t* id)
+{
+    RocprofDataSourceShared::singleton();	// CRITICAL: static init
+
+    id->name = "rpd_tracer";
+    s->clientId = id;
+
+    // return pointer to configure data
+    return &s->cfg;
+}
+
+
 int RocprofDataSource::toolInit(rocprofiler_client_finalize_t finialize_func, void* tool_data)
 {
-    fprintf(stderr, "RocprofDataSource::toolInit\n");
-
-    name_info = common::get_buffer_tracing_names();
+    s->name_info = common::get_buffer_tracing_names();
 
     auto agent_info = get_gpu_device_agents();
+
     for (auto agent : agent_info) {
-        agents[agent.id.handle] = agent;
+        s->agents[agent.id.handle] = agent;
     }
 
-    rocprofiler_create_context(&client_ctx);
+    // Common context
+    //-------------------------------------------------------
+    rocprofiler_create_context(&s->utilityContext);
 
-    rocprofiler_configure_callback_tracing_service(client_ctx,
+    // Code Objects
+    auto code_object_ops = std::vector<rocprofiler_tracing_operation_t>{
+        ROCPROFILER_CODE_OBJECT_DEVICE_KERNEL_SYMBOL_REGISTER};
+
+    rocprofiler_configure_callback_tracing_service(s->utilityContext,
+                                                   ROCPROFILER_CALLBACK_TRACING_CODE_OBJECT,
+                                                   code_object_ops.data(),
+                                                   code_object_ops.size(),
+                                                   RocprofDataSource::code_object_callback,
+                                                   nullptr);
+
+    {
+        int isValid = 0;
+        rocprofiler_context_is_valid(s->utilityContext, &isValid);
+        if (isValid == 0) {
+            s->utilityContext.handle = 0;   // Can't destroy it, so leak it
+            return -1;
+        }
+    }
+
+    rocprofiler_start_context(s->utilityContext);
+
+
+
+    // Instance s->contexts
+    //-------------------------------------------------------
+
+    for (auto &context : s->contexts) {
+
+        rocprofiler_create_context(&context);
+
+        rocprofiler_configure_callback_tracing_service(context,
                                                    ROCPROFILER_CALLBACK_TRACING_HIP_RUNTIME_API,
                                                    nullptr,
                                                    0,
@@ -410,7 +505,7 @@ int RocprofDataSource::toolInit(rocprofiler_client_finalize_t finialize_func, vo
                                                    nullptr);
                                                    //tool_data);
 
-    rocprofiler_configure_callback_tracing_service(client_ctx,
+        rocprofiler_configure_callback_tracing_service(context,
                                                    ROCPROFILER_CALLBACK_TRACING_KERNEL_DISPATCH,
                                                    nullptr,
                                                    0,
@@ -418,7 +513,7 @@ int RocprofDataSource::toolInit(rocprofiler_client_finalize_t finialize_func, vo
                                                    nullptr);
                                                    //tool_data);
 
-    rocprofiler_configure_callback_tracing_service(client_ctx,
+        rocprofiler_configure_callback_tracing_service(context,
                                                    ROCPROFILER_CALLBACK_TRACING_MEMORY_COPY,
                                                    nullptr,
                                                    0,
@@ -426,17 +521,14 @@ int RocprofDataSource::toolInit(rocprofiler_client_finalize_t finialize_func, vo
                                                    nullptr);
                                                    //tool_data);
 
-
-    // Code Objects
-    auto code_object_ops = std::vector<rocprofiler_tracing_operation_t>{
-        ROCPROFILER_CODE_OBJECT_DEVICE_KERNEL_SYMBOL_REGISTER};
-
-    rocprofiler_configure_callback_tracing_service(client_ctx,
-                                                   ROCPROFILER_CALLBACK_TRACING_CODE_OBJECT,
-                                                   code_object_ops.data(),
-                                                   code_object_ops.size(),
-                                                   RocprofDataSource::code_object_callback,
-                                                   nullptr);
+        int isValid = 0;
+        rocprofiler_context_is_valid(context, &isValid);
+        if (isValid == 0) {
+            context.handle = 0;   // Can't destroy it, so leak it
+            return -1;
+        }
+        rocprofiler_start_context(context);
+    }
 
 #if 0
     constexpr auto buffer_size_bytes      = 0x40000;
@@ -467,14 +559,6 @@ int RocprofDataSource::toolInit(rocprofiler_client_finalize_t finialize_func, vo
     rocprofiler_assign_callback_thread(client_buffer, client_thread);
 #endif
 
-    int valid_ctx = 0;
-    rocprofiler_context_is_valid(client_ctx, &valid_ctx);
-    if (valid_ctx == 0) {
-       client_ctx.handle = 0;	// Can't destroy it, so leak it
-       return -1;
-    }
-
-    rocprofiler_start_context(client_ctx);
     return 0;
 }
 
@@ -488,8 +572,10 @@ void RocprofDataSource::toolFinialize(void* tool_data)
     // FIXME: kernel code objects are already being removed by this point
     //        keeping names (only) around to remedy this
 
-    rocprofiler_stop_context(client_ctx);
-    rocprofiler_flush_buffer(client_buffer);	// hopfully this blocks
-
-    client_ctx.handle = 0;	// save us from ourselves
+    rocprofiler_stop_context(s->utilityContext);
+    s->utilityContext.handle = 0;    // save us from ourselves
+    for (auto &context : s->contexts) {
+        rocprofiler_stop_context(context);
+        context.handle = 0;
+    }
 }

--- a/rpd_tracer/RocprofDataSource.h
+++ b/rpd_tracer/RocprofDataSource.h
@@ -30,14 +30,6 @@
 #include "DataSource.h"
 #include "ApiIdList.h"
 
-#if 0
-class RocmApiIdList : public ApiIdList
-{
-public:
-    RocmApiIdList() { ; }
-    uint32_t mapName(const std::string &apiName) override;
-};
-#endif
 
 class RocprofDataSourcePrivate;
 class RocprofDataSource : public DataSource

--- a/rpd_tracer/RocprofDataSource.h
+++ b/rpd_tracer/RocprofDataSource.h
@@ -1,0 +1,69 @@
+/*********************************************************************************
+* Copyright (c) 2021 - 2024 Advanced Micro Devices, Inc. All rights reserved.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+********************************************************************************/
+#pragma once
+
+//#include <roctracer.h>
+
+#include <string>
+
+#include <rocprofiler-sdk/registration.h>
+
+#include "DataSource.h"
+#include "ApiIdList.h"
+
+#if 0
+class RocmApiIdList : public ApiIdList
+{
+public:
+    RocmApiIdList() { ; }
+    uint32_t mapName(const std::string &apiName) override;
+};
+#endif
+
+
+class RocprofDataSource : public DataSource
+{
+public:
+    //RocprofDataSource();
+    void init() override;
+    void end() override;
+    void startTracing() override;
+    void stopTracing() override;
+    void flush() override;
+
+private:
+    //RocmApiIdList m_apiList;
+
+//    roctracer_pool_t *m_hccPool{nullptr};
+//    static void api_callback(uint32_t domain, uint32_t cid, const void* callback_data, void* arg);
+//    static void hcc_activity_callback(const char* begin, const char* end, void* arg);
+
+public:
+      static int toolInit(rocprofiler_client_finalize_t finalize_func, void* tool_data);
+      static void toolFinialize(void* tool_data);
+
+      static void api_callback(rocprofiler_callback_tracing_record_t record, rocprofiler_user_data_t* user_data, void* callback_data);
+      static void buffer_callback(rocprofiler_context_id_t context, rocprofiler_buffer_id_t buffer_id, rocprofiler_record_header_t** headers, size_t num_headers, void* user_data, uint64_t drop_count);
+      static void code_object_callback(rocprofiler_callback_tracing_record_t record, rocprofiler_user_data_t* user_data, void* callback_data);
+
+};
+

--- a/rpd_tracer/RocprofDataSource.h
+++ b/rpd_tracer/RocprofDataSource.h
@@ -39,11 +39,12 @@ public:
 };
 #endif
 
-
+class RocprofDataSourcePrivate;
 class RocprofDataSource : public DataSource
 {
 public:
-    //RocprofDataSource();
+    RocprofDataSource();
+    ~RocprofDataSource();
     void init() override;
     void end() override;
     void startTracing() override;
@@ -51,11 +52,10 @@ public:
     void flush() override;
 
 private:
-    //RocmApiIdList m_apiList;
+    RocprofDataSourcePrivate *d;
+    friend class RocprofDataSourcePrivate;
 
-//    roctracer_pool_t *m_hccPool{nullptr};
-//    static void api_callback(uint32_t domain, uint32_t cid, const void* callback_data, void* arg);
-//    static void hcc_activity_callback(const char* begin, const char* end, void* arg);
+    //RocmApiIdList m_apiList;
 
 public:
       static int toolInit(rocprofiler_client_finalize_t finalize_func, void* tool_data);

--- a/rpd_tracer/RocprofDataSource.h
+++ b/rpd_tracer/RocprofDataSource.h
@@ -62,6 +62,7 @@ public:
       static void toolFinialize(void* tool_data);
 
       static void api_callback(rocprofiler_callback_tracing_record_t record, rocprofiler_user_data_t* user_data, void* callback_data);
+      static void roctx_callback(rocprofiler_callback_tracing_record_t record, rocprofiler_user_data_t* user_data, void* callback_data);
       static void buffer_callback(rocprofiler_context_id_t context, rocprofiler_buffer_id_t buffer_id, rocprofiler_record_header_t** headers, size_t num_headers, void* user_data, uint64_t drop_count);
       static void code_object_callback(rocprofiler_callback_tracing_record_t record, rocprofiler_user_data_t* user_data, void* callback_data);
 

--- a/rpd_tracer/RoctracerDataSource.cpp
+++ b/rpd_tracer/RoctracerDataSource.cpp
@@ -82,7 +82,7 @@ namespace {
 
     void createDeviceMap() {
         int dc = 0;
-        hipGetDeviceCount(&dc);
+        int ret = hipGetDeviceCount(&dc);
         hsa_iterate_agents(
             [](hsa_agent_t agent, void* data) {
            auto &deviceOffset = *static_cast<int*>(data);

--- a/rpd_tracer/Table.h
+++ b/rpd_tracer/Table.h
@@ -167,6 +167,7 @@ public:
         int dstDevice {0};
         int srcDevice {0};
         int kind {0};
+        std::string kindStr;
         bool sync {false};
         bool pinned {false};
         sqlite3_int64 api_id {0};   // Baseclass ApiTable primary key (correlation id)


### PR DESCRIPTION
Collect hip apis and ops from rocprofiler-sdk rather than roctracer.
RocprofileDataSource standing in for RoctracerDataSource.
