### PR TITLE
Namespace everything. Add lazy startup initialization

### DIFF
--- a/rpd_tracer/ApiIdList.cpp
+++ b/rpd_tracer/ApiIdList.cpp
@@ -25,6 +25,9 @@
 //#include <roctracer_hip.h>
 // FIXME: make this work for cud and hip or turn into interface
 
+using rpdtracer::ApiIdList;
+
+
 ApiIdList::ApiIdList()
 : m_invert(true)
 {

--- a/rpd_tracer/ApiIdList.h
+++ b/rpd_tracer/ApiIdList.h
@@ -36,6 +36,8 @@
 //   "normal mode": things you add() are the only things matching the filter
 //   invertMode() == true: All things match filter except what you add()
 
+namespace rpdtracer {
+
 class ApiIdList
 {
 public:
@@ -57,4 +59,6 @@ private:
   std::unordered_map<uint32_t, uint32_t> m_filter;	// apiId -> "1"
   bool m_invert;
 };
+
+}    // namespace rpdtracer
 

--- a/rpd_tracer/ApiTable.cpp
+++ b/rpd_tracer/ApiTable.cpp
@@ -29,6 +29,9 @@
 
 #include "Utility.h"
 
+using rpdtracer::ApiTable;
+using rpdtracer::ApiTablePrivate;
+
 
 const char *SCHEMA_API = R"|(
 CREATE TEMPORARY TABLE "temp_rocpd_api" ("id" integer NOT NULL PRIMARY KEY AUTOINCREMENT, "pid" integer NOT NULL, "tid" integer NOT NULL, "start" integer NOT NULL, "end" integer NOT NULL, "apiName_id" bigint NOT NULL REFERENCES "rocpd_string" ("id") DEFERRABLE INITIALLY DEFERRED, "category_id" bigint NOT NULL REFERENCES "rocpd_string" ("id") DEFERRABLE INITIALLY DEFERRED, "domain_id" bigint NOT NULL REFERENCES "rocpd_string" ("id") DEFERRABLE INITIALLY DEFERRED, "args_id" bigint NOT NULL REFERENCES "rocpd_ustring" ("id") DEFERRABLE INITIALLY DEFERRED)

--- a/rpd_tracer/BufferedTable.cpp
+++ b/rpd_tracer/BufferedTable.cpp
@@ -6,6 +6,8 @@
 
 #include <thread>
 
+using rpdtracer::BufferedTable;
+using rpdtracer::BufferedTablePrivate;
 
 class BufferedTablePrivate
 {

--- a/rpd_tracer/CopyApiTable.cpp
+++ b/rpd_tracer/CopyApiTable.cpp
@@ -28,6 +28,9 @@
 #include "rpd_tracer.h"
 #include "Utility.h"
 
+using rpdtracer::CopyApiTable;
+using rpdtracer::CopyApiTablePrivate;
+
 
 const char *SCHEMA_COPYAPI = "CREATE TEMPORARY TABLE \"temp_rocpd_copyapi\" (\"api_ptr_id\" integer NOT NULL PRIMARY KEY REFERENCES \"rocpd_api\" (\"id\") DEFERRABLE INITIALLY DEFERRED, \"stream\" varchar(18) NOT NULL, \"size\" integer NOT NULL, \"width\" integer NOT NULL, \"height\" integer NOT NULL, \"kind\" integer NOT NULL, \"dst\" varchar(18) NOT NULL, \"src\" varchar(18) NOT NULL, \"dstDevice\" integer NOT NULL, \"srcDevice\" integer NOT NULL, \"sync\" bool NOT NULL, \"pinned\" bool NOT NULL);";
 

--- a/rpd_tracer/CuptiDataSource.cpp
+++ b/rpd_tracer/CuptiDataSource.cpp
@@ -32,6 +32,10 @@
 #include "Logger.h"
 #include "Utility.h"
 
+using rpdtracer::DataSource;
+using rpdtracer::CuptiDataSource;
+using rpdtracer::CudaApiIdList;
+
 
 // Create a factory for the Logger to locate and use
 extern "C" {

--- a/rpd_tracer/CuptiDataSource.h
+++ b/rpd_tracer/CuptiDataSource.h
@@ -32,6 +32,8 @@
 #include "DataSource.h"
 #include "ApiIdList.h"
 
+namespace rpdtracer {
+
 class CudaApiIdList : public ApiIdList
 {
 public:
@@ -63,3 +65,5 @@ private:
     static void CUPTIAPI bufferCompleted(CUcontext ctx, uint32_t streamId, uint8_t *buffer, size_t size, size_t validSize);
 
 };
+
+}    // namespace rpdtracer

--- a/rpd_tracer/DataSource.h
+++ b/rpd_tracer/DataSource.h
@@ -23,6 +23,8 @@
 
 //#include "Logger.h"
 
+namespace rpdtracer {
+
 class DataSource
 {
 public:
@@ -33,3 +35,5 @@ public:
     virtual void stopTracing() = 0;
     virtual void flush() = 0;
 };
+
+}    // namespace rpdtracer

--- a/rpd_tracer/DbResource.cpp
+++ b/rpd_tracer/DbResource.cpp
@@ -23,6 +23,10 @@
 
 #include <fmt/format.h>
 
+using rpdtracer::DbResource;
+using rpdtracer::DbResourcePrivate;
+
+
 class DbResourcePrivate
 {
 public:

--- a/rpd_tracer/DbResource.h
+++ b/rpd_tracer/DbResource.h
@@ -6,6 +6,8 @@
 #include <sqlite3.h>
 #include <string>
 
+namespace rpdtracer {
+
 class DbResourcePrivate;
 class DbResource
 {
@@ -23,3 +25,5 @@ private:
     DbResourcePrivate *d;
     friend class DbResourcePrivate;
 };
+
+}    // namespace rpdtracer

--- a/rpd_tracer/KernelApiTable.cpp
+++ b/rpd_tracer/KernelApiTable.cpp
@@ -28,6 +28,9 @@
 #include "rpd_tracer.h"
 #include "Utility.h"
 
+using rpdtracer::KernelApiTable;
+using rpdtracer::KernelApiTablePrivate;
+
 
 const char *SCHEMA_KERNELAPI = R"|(
 CREATE TEMPORARY TABLE  "temp_rocpd_kernelapi" ("api_ptr_id" bigint NOT NULL PRIMARY KEY REFERENCES "rocpd_api" ("id") DEFERRABLE INITIALLY DEFERRED, "stream" varchar(18) NOT NULL, "gridX" integer NOT NULL, "gridY" integer NOT NULL, "gridZ" integer NOT NULL, "workgroupX" integer NOT NULL, "workgroupY" integer NOT NULL, "workgroupZ" integer NOT NULL, "groupSegmentSize" integer NOT NULL, "privateSegmentSize" integer NOT NULL, "kernelName_id" bigint NOT NULL REFERENCES "rocpd_string" ("id") DEFERRABLE INITIALLY DEFERRED)

--- a/rpd_tracer/Logger.cpp
+++ b/rpd_tracer/Logger.cpp
@@ -28,6 +28,7 @@
 
 #include "Utility.h"
 
+using rpdtracer::Logger;
 
 #if 0
 static void rpdInit() __attribute__((constructor));
@@ -74,11 +75,14 @@ void rpd_rangePop()
 
 // GFH - This mirrors the function in the pre-refactor code.  Allows both code paths to compile.
 //   See table classes for users.  Todo: build a proper threaded record writer
-void createOverheadRecord(uint64_t start, uint64_t end, const std::string &name, const std::string &args)
+void rpdtracer::createOverheadRecord(uint64_t start, uint64_t end, const std::string &name, const std::string &args)
 {
     Logger::singleton().createOverheadRecord(start, end, name, args);
 }
 
+namespace {
+    bool loggerInitialized { false };
+}
 
 Logger& Logger::singleton()
 {
@@ -87,11 +91,20 @@ Logger& Logger::singleton()
 }
 
 void Logger::rpdInit() {
-    Logger::singleton().init();
+    bool doInit = true;
+    char *val = getenv("RPDT_DELAYINIT");
+    if (val != NULL) {
+        int delayinit = atoi(val);
+        if (delayinit != 0)
+            doInit = false;
+    }
+    if (doInit)
+        Logger::singleton();
 }
 
 void Logger::rpdFinalize() {
-    Logger::singleton().finalize();
+    if (loggerInitialized)
+        Logger::singleton().finalize();
 }
 
 
@@ -272,6 +285,8 @@ void Logger::init()
         int val = atoi(stackframe);
         m_writeStackFrames = (val != 0);
     }
+
+    loggerInitialized = true;  // detect lazy init
 }
 
 static bool doFinalize = true;

--- a/rpd_tracer/Logger.h
+++ b/rpd_tracer/Logger.h
@@ -29,12 +29,14 @@
 #include "Table.h"
 #include "DataSource.h"
 
+namespace rpdtracer {
+
 const sqlite_int64 EMPTY_STRING_ID = 1;
 
 class Logger
 {
 public:
-    //Logger();
+    Logger() { init(); }
     static Logger& singleton();
 
     // Table writer classes.  Used directly by DataSources
@@ -97,3 +99,5 @@ private:
     std::thread *m_worker {nullptr};
     void autoflushWorker();
 };
+
+}    // namespace rpdtracer

--- a/rpd_tracer/MetadataTable.cpp
+++ b/rpd_tracer/MetadataTable.cpp
@@ -25,6 +25,9 @@
 
 #include "Utility.h"
 
+using rpdtracer::MetadataTable;
+using rpdtracer::MetadataTablePrivate;
+
 
 //const char *SCHEMA_OP = "CREATE TEMPORARY TABLE \"temp_rocpd_op\" (\"id\" integer NOT NULL PRIMARY KEY AUTOINCREMENT, \"gpuId\" integer NOT NULL, \"queueId\" integer NOT NULL, \"sequenceId\" integer NOT NULL, \"completionSignal\" varchar(18) NOT NULL, \"start\" integer NOT NULL, \"end\" integer NOT NULL, \"description_id\" integer NOT NULL REFERENCES \"rocpd_string\" (\"id\") DEFERRABLE INITIALLY DEFERRED, \"opType_id\" integer NOT NULL REFERENCES \"rocpd_string\" (\"id\") DEFERRABLE INITIALLY DEFERRED)";
 

--- a/rpd_tracer/MonitorTable.cpp
+++ b/rpd_tracer/MonitorTable.cpp
@@ -29,6 +29,9 @@
 #include "rpd_tracer.h"
 #include "Utility.h"
 
+using rpdtracer::MonitorTable;
+using rpdtracer::MonitorTablePrivate;
+
 
 const char *SCHEMA_MONITOR = "CREATE TEMPORARY TABLE \"temp_rocpd_monitor\" (\"id\" integer NOT NULL PRIMARY KEY AUTOINCREMENT, \"deviceType\" varchar(16) NOT NULL, \"deviceId\" integer NOT NULL, \"monitorType\" varchar(16) NOT NULL, \"start\" integer NOT NULL, \"end\" integer NOT NULL, \"value\" varchar(255) NOT NULL)";
 

--- a/rpd_tracer/OpTable.cpp
+++ b/rpd_tracer/OpTable.cpp
@@ -29,6 +29,9 @@
 #include "rpd_tracer.h"
 #include "Utility.h"
 
+using rpdtracer::OpTable;
+using rpdtracer::OpTablePrivate;
+
 
 const char *SCHEMA_OP = R"|(
 CREATE TEMPORARY TABLE "temp_rocpd_op" ("id" integer NOT NULL PRIMARY KEY AUTOINCREMENT, "gpuId" integer NOT NULL, "queueId" integer NOT NULL, "sequenceId" integer NOT NULL, "start" integer NOT NULL, "end" integer NOT NULL, "description_id" bigint NOT NULL REFERENCES "rocpd_string" ("id") DEFERRABLE INITIALLY DEFERRED, "opType_id" bigint NOT NULL REFERENCES "rocpd_string" ("id") DEFERRABLE INITIALLY DEFERRED);

--- a/rpd_tracer/RocmSmiDataSource.h
+++ b/rpd_tracer/RocmSmiDataSource.h
@@ -11,6 +11,7 @@
 #include <mutex>
 #include <condition_variable>
 
+namespace rpdtracer {
 
 class RocmSmiDataSource : public DataSource
 {
@@ -35,3 +36,4 @@ private:
     sqlite3_int64 m_period { 10000 };
 };
 
+}    // namespace rpdtracer

--- a/rpd_tracer/RocprofDataSource.cpp
+++ b/rpd_tracer/RocprofDataSource.cpp
@@ -40,6 +40,11 @@
 #include "Logger.h"
 #include "Utility.h"
 
+using rpdtracer::DataSource;
+using rpdtracer::RocprofDataSource;
+using rpdtracer::RocprofDataSourcePrivate;
+//using rpdtracer::RocprofApiIdList;
+
 
 // Create a factory for the Logger to locate and use
 extern "C" {
@@ -83,7 +88,7 @@ namespace
                    int32_t           dereference_count,
                    void*             cb_data) -> int {
 
-                auto &crow = *(static_cast<CopyApiTable::row*>(cb_data));
+                auto &crow = *(static_cast<rpdtracer::CopyApiTable::row*>(cb_data));
                 if (strcmp("dst", arg_name) == 0) {
                     crow.dst = std::string(arg_value_str);
                 }
@@ -116,7 +121,7 @@ namespace
                    void*             cb_data) -> int {
 
                 if (strcmp("stream", arg_name) == 0) {
-                    auto &krow = *(static_cast<KernelApiTable::row*>(cb_data));
+                    auto &krow = *(static_cast<rpdtracer::KernelApiTable::row*>(cb_data));
                     krow.stream = std::string(arg_value_str);
                 }
                 return 0;
@@ -220,7 +225,7 @@ namespace
        return false;
     }
 
-    class RocprofApiIdList : public ApiIdList
+    class RocprofApiIdList : public rpdtracer::ApiIdList
     {
     public:
         RocprofApiIdList(buffer_name_info &names);

--- a/rpd_tracer/RocprofDataSource.h
+++ b/rpd_tracer/RocprofDataSource.h
@@ -30,6 +30,7 @@
 #include "DataSource.h"
 #include "ApiIdList.h"
 
+namespace rpdtracer {
 
 class RocprofDataSourcePrivate;
 class RocprofDataSource : public DataSource
@@ -60,3 +61,4 @@ public:
 
 };
 
+}    // namespace rpdtracer

--- a/rpd_tracer/RoctracerDataSource.cpp
+++ b/rpd_tracer/RoctracerDataSource.cpp
@@ -32,6 +32,10 @@
 #include "Logger.h"
 #include "Utility.h"
 
+using rpdtracer::DataSource;
+using rpdtracer::RoctracerDataSource;
+using rpdtracer::RocmApiIdList;
+
 
 // Create a factory for the Logger to locate and use
 extern "C" {
@@ -903,6 +907,7 @@ void RoctracerDataSource::hcc_activity_callback(const char* begin, const char* e
 
 
 void RoctracerDataSource::init() {
+    createDeviceMap();
 
     // Pick some apis to ignore
     m_apiList.setInvertMode(true);  // Omit the specified api
@@ -963,7 +968,7 @@ void RoctracerDataSource::init() {
     roctracer_enable_domain_activity_expl(ACTIVITY_DOMAIN_HCC_OPS, m_hccPool);
 #endif
 
-    createDeviceMap();
+    //createDeviceMap();
     stopTracing();
 }
 

--- a/rpd_tracer/RoctracerDataSource.h
+++ b/rpd_tracer/RoctracerDataSource.h
@@ -31,6 +31,8 @@
 #include "ApiIdList.h"
 #include "Logger.h"
 
+namespace rpdtracer {
+
 class RocmApiIdList : public ApiIdList
 {
 public:
@@ -56,3 +58,5 @@ private:
     static void api_callback(uint32_t domain, uint32_t cid, const void* callback_data, void* arg);
     static void hcc_activity_callback(const char* begin, const char* end, void* arg);
 };
+
+}    // namespace rpdtracer

--- a/rpd_tracer/StackFrameTable.cpp
+++ b/rpd_tracer/StackFrameTable.cpp
@@ -28,6 +28,9 @@
 #include "rpd_tracer.h"
 #include "Utility.h"
 
+using rpdtracer::StackFrameTable;
+using rpdtracer::StackFrameTablePrivate;
+
 
 const char *SCHEMA = R"sql(CREATE TEMPORARY TABLE "temp_rocpd_stackframe" ("id" integer NOT NULL PRIMARY KEY AUTOINCREMENT, "api_ptr_id" integer NOT NULL REFERENCES "rocpd_api" ("id") DEFERRABLE INITIALLY DEFERRED, "depth" integer NOT NULL, "name_id" integer NOT NULL REFERENCES "rocpd_string" ("id") DEFERRABLE INITIALLY DEFERRED);)sql";
 

--- a/rpd_tracer/StringTable.cpp
+++ b/rpd_tracer/StringTable.cpp
@@ -29,6 +29,9 @@
 #include "rpd_tracer.h"
 #include "Utility.h"
 
+using rpdtracer::StringTable;
+using rpdtracer::StringTablePrivate;
+
 
 const char *SCHEMA_STRING = "CREATE TEMPORARY TABLE \"temp_rocpd_string\" (\"id\" integer NOT NULL PRIMARY KEY AUTOINCREMENT, \"string\" varchar(4096) NOT NULL)";
 

--- a/rpd_tracer/Table.cpp
+++ b/rpd_tracer/Table.cpp
@@ -4,6 +4,8 @@
 #include "Table.h"
 #include "Utility.h"
 
+using rpdtracer::Table;
+
 int busy_handler(void *data, int count)
 {
     count = (count < 9) ? count : 8;

--- a/rpd_tracer/Table.h
+++ b/rpd_tracer/Table.h
@@ -8,6 +8,8 @@
 #include <mutex>
 #include <condition_variable>
 
+namespace rpdtracer {
+
 class Table
 {
 public:
@@ -330,3 +332,5 @@ private:
     virtual void writeRows() override;
     virtual void flushRows() override;
 };
+
+}    // namespace rpdtracer

--- a/rpd_tracer/UStringTable.cpp
+++ b/rpd_tracer/UStringTable.cpp
@@ -29,6 +29,9 @@
 #include "rpd_tracer.h"
 #include "Utility.h"
 
+using rpdtracer::UStringTable;
+using rpdtracer::UStringTablePrivate;
+
 
 const char *SCHEMA_USTRING = R"|(
 CREATE TEMPORARY TABLE "temp_rocpd_ustring" ("id" integer NOT NULL PRIMARY KEY AUTOINCREMENT, "string" varchar(4096) NOT NULL);

--- a/rpd_tracer/Unwind.cpp
+++ b/rpd_tracer/Unwind.cpp
@@ -23,6 +23,10 @@
 #include <sqlite3.h>
 #include "Logger.h"
 
+namespace rpdtracer {
+    int unwind(rpdtracer::Logger &logger, const char *api, const sqlite_int64 api_id);
+}    // namespace rpdtracer
+
 #ifdef RPD_STACKFRAME_SUPPORT
 #include <cpptrace/cpptrace.hpp>
 #include <sstream>
@@ -36,7 +40,7 @@
 
 static std::once_flag registerDoubleAgain_once;
 
-int unwind(Logger &logger, const char *api, const sqlite_int64 api_id) {
+int rpdtracer::unwind(rpdtracer::Logger &logger, const char *api, const sqlite_int64 api_id) {
 
     if (!logger.writeStackFrames()) return 0;
 
@@ -90,16 +94,15 @@ int unwind(Logger &logger, const char *api, const sqlite_int64 api_id) {
         n++;
     }
 
-    std::call_once(registerDoubleAgain_once, atexit, Logger::rpdFinalize);
+    std::call_once(registerDoubleAgain_once, atexit, rpdtracer::Logger::rpdFinalize);
 
     return 0;
 }
 
 #else
 
-int unwind(Logger &logger, const char *api, const sqlite_int64 api_id) {
+int rpdtracer::unwind(rpdtracer::Logger &logger, const char *api, const sqlite_int64 api_id) {
     return 0;
 }
 
 #endif
-

--- a/rpd_tracer/Utility.h
+++ b/rpd_tracer/Utility.h
@@ -10,6 +10,7 @@
 #include <cstddef>
 #include <cstdint>
 
+namespace rpdtracer {
 
 typedef uint64_t timestamp_t;
 
@@ -47,3 +48,5 @@ void createOverheadRecord(uint64_t start, uint64_t end, const std::string &name,
 
 class Logger;
 int unwind(Logger &logger, const char *api, const sqlite_int64 api_id);
+
+}    // namespace rpdtracer

--- a/rpd_tracer/loadTracer.sh
+++ b/rpd_tracer/loadTracer.sh
@@ -40,6 +40,7 @@ fi
 
 export RPDT_FILENAME=${OUTPUT_FILE}
 export RPDT_AUTOSTART=0
+export RPDT_DELAYINIT=1
 
 # Work around past poor planning
 USELIBS=librpd_tracer.so

--- a/rpd_tracer/rpd_tracer.h
+++ b/rpd_tracer/rpd_tracer.h
@@ -32,4 +32,8 @@ extern "C" {
     void rpd_rangePop();
 }
 
+namespace rpdtracer {
+
 void createOverheadRecord(uint64_t start, uint64_t end, const std::string &name, const std::string &args);
+
+}    // namespace rpdtracer


### PR DESCRIPTION
Move everything under the rpdtracer namespace.  This may help with symbol collisions when dynamically loading.

Add support for late initialization.  RPDT_DELAYINIT=1 will avoid all setup until the first access of the Logger instance.
When paired with RPDT_AUTOSTART=0 (which loadTracer.sh does now), a process that doesn't explicitly start recording will fully avoid any startup overhead.