### PR TITLE
Have rpd_tracer write schema into uninitialized files

### DIFF
--- a/rpd_tracer/Logger.cpp
+++ b/rpd_tracer/Logger.cpp
@@ -27,6 +27,7 @@
 #include <dlfcn.h>
 
 #include "Utility.h"
+#include "Schema.h"
 
 using rpdtracer::Logger;
 
@@ -202,6 +203,10 @@ void Logger::init()
     if (filename == NULL)
         filename = "./trace.rpd";
     m_filename = filename;
+
+    // Ensure schema exists
+
+    ensureSchema(filename);
 
     // Create table recorders
 

--- a/rpd_tracer/Makefile
+++ b/rpd_tracer/Makefile
@@ -68,6 +68,20 @@ all: | $(RPD_MAIN)
 
 .PHONY: all 
 
+SCHEMA_DIR = ../rocpd_python/rocpd/schema_data
+
+tableSchema.h: $(SCHEMA_DIR)/tableSchema.cmd
+	printf 'static const unsigned char tableSchema_cmd[] = {\n' > $@
+	xxd -i < $< >> $@
+	printf ', 0x00\n};\n' >> $@
+
+utilitySchema.h: $(SCHEMA_DIR)/utilitySchema.cmd
+	printf 'static const unsigned char utilitySchema_cmd[] = {\n' > $@
+	xxd -i < $< >> $@
+	printf ', 0x00\n};\n' >> $@
+
+Schema.o: tableSchema.h utilitySchema.h
+
 
 $(RPD_MAIN): $(RPD_OBJS)
 	$(CXX) -o $@ $^ -shared -rdynamic -std=c++11 $(RPD_LIBS) -Wl,--version-script=marker_shim.ver -g
@@ -92,4 +106,4 @@ uninstall:
 	rm $(PREFIX)/bin/$(RPD_SCRIPT)
 .PHONY: clean
 clean:
-	rm -f *.o *.so *.d
+	rm -f *.o *.so *.d tableSchema.h utilitySchema.h

--- a/rpd_tracer/Schema.cpp
+++ b/rpd_tracer/Schema.cpp
@@ -1,0 +1,62 @@
+/**************************************************************************
+ * Copyright (c) 2023 Advanced Micro Devices, Inc.
+ **************************************************************************/
+#include "Schema.h"
+
+#include <sqlite3.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "tableSchema.h"
+#include "utilitySchema.h"
+
+namespace rpdtracer {
+
+void ensureSchema(const char *basefile)
+{
+    sqlite3 *db = nullptr;
+    int ret = sqlite3_open(basefile, &db);
+    if (ret != SQLITE_OK) {
+        fprintf(stderr, "rpd_tracer: cannot open database %s: %s\n", basefile, sqlite3_errmsg(db));
+        return;
+    }
+
+    // Use BEGIN EXCLUSIVE to serialize against other processes
+    ret = sqlite3_exec(db, "BEGIN EXCLUSIVE TRANSACTION", nullptr, nullptr, nullptr);
+    if (ret != SQLITE_OK) {
+        fprintf(stderr, "rpd_tracer: cannot lock database %s: %s\n", basefile, sqlite3_errmsg(db));
+        sqlite3_close(db);
+        return;
+    }
+
+    // Check if schema already exists
+    sqlite3_stmt *stmt = nullptr;
+    bool hasSchema = false;
+    ret = sqlite3_prepare_v2(db, "SELECT 1 FROM sqlite_master WHERE type='table' AND name='rocpd_string'", -1, &stmt, nullptr);
+    if (ret == SQLITE_OK) {
+        if (sqlite3_step(stmt) == SQLITE_ROW)
+            hasSchema = true;
+        sqlite3_finalize(stmt);
+    }
+
+    if (!hasSchema) {
+        // tableSchema and utilitySchema are null-terminated via xxd -i
+        char *errmsg = nullptr;
+        ret = sqlite3_exec(db, reinterpret_cast<const char *>(tableSchema_cmd), nullptr, nullptr, &errmsg);
+        if (ret != SQLITE_OK) {
+            fprintf(stderr, "rpd_tracer: tableSchema error: %s\n", errmsg);
+            sqlite3_free(errmsg);
+        }
+
+        ret = sqlite3_exec(db, reinterpret_cast<const char *>(utilitySchema_cmd), nullptr, nullptr, &errmsg);
+        if (ret != SQLITE_OK) {
+            fprintf(stderr, "rpd_tracer: utilitySchema error: %s\n", errmsg);
+            sqlite3_free(errmsg);
+        }
+    }
+
+    sqlite3_exec(db, "END TRANSACTION", nullptr, nullptr, nullptr);
+    sqlite3_close(db);
+}
+
+}  // namespace rpdtracer

--- a/rpd_tracer/Schema.h
+++ b/rpd_tracer/Schema.h
@@ -1,0 +1,10 @@
+/**************************************************************************
+ * Copyright (c) 2023 Advanced Micro Devices, Inc.
+ **************************************************************************/
+#pragma once
+
+namespace rpdtracer {
+
+void ensureSchema(const char *basefile);
+
+}    // namespace rpdtracer

--- a/rpd_tracer/loadTracer.sh
+++ b/rpd_tracer/loadTracer.sh
@@ -27,16 +27,8 @@ if [ "$1" = "-o" ] ; then
   shift
   shift
 fi
- 
-if [ -e ${OUTPUT_FILE} ] ; then
-  rm ${OUTPUT_FILE}
-fi
 
-python3 -m rocpd.schema --create ${OUTPUT_FILE}
-if [ $? != 0 ] ; then
-  echo "Error: Could not create rpd file. Please run 'python setup.py install' from the rocpd_python dir"
-  exit
-fi
+rm -f ${OUTPUT_FILE}
 
 export RPDT_FILENAME=${OUTPUT_FILE}
 export RPDT_AUTOSTART=0

--- a/rpd_tracer/rpdTracerControl.py
+++ b/rpd_tracer/rpdTracerControl.py
@@ -58,14 +58,7 @@ class rpdTracerControl:
         if cls.__initFile == True and cls.__active == True:
             if os.path.exists(cls.__filename):
                 os.remove(cls.__filename)
-            # Create new file and write schema
-            schema = RocpdSchema()
-            connection = sqlite3.connect(cls.__filename)
-            schema.writeSchema(connection)
-            connection.commit()
-            connection.close()
-            #
-            #os.environ["RPDT_FILENAME"] = cls.__filename
+            # Schema added to new file by tracer
             cls.__initFile = False   
         os.environ["RPDT_FILENAME"] = cls.__filename
 

--- a/rpd_tracer/runTracer.sh
+++ b/rpd_tracer/runTracer.sh
@@ -27,16 +27,8 @@ if [ "$1" = "-o" ] ; then
   shift
   shift
 fi
- 
-if [ -e ${OUTPUT_FILE} ] ; then
-  rm ${OUTPUT_FILE}
-fi
 
-python3 -m rocpd.schema --create ${OUTPUT_FILE}
-if [ $? != 0 ] ; then
-  echo "Error: Could not create rpd file. Please run 'python setup.py install' from the rocpd_python dir"
-  exit
-fi
+rm -f ${OUTPUT_FILE}
 
 export RPDT_FILENAME=${OUTPUT_FILE}
 


### PR DESCRIPTION
Tracer can now write schema into a new empty file.
Runtracer and loadtracer no longer have to.
Easier use from C-api