### PR TITLE
Improve shutdown hygene

### DIFF
--- a/rpd_tracer/AmdSmiDataSource.cpp
+++ b/rpd_tracer/AmdSmiDataSource.cpp
@@ -334,8 +334,12 @@ void AmdSmiDataSource::init()
 
 void AmdSmiDataSource::end()
 {
+    if (d == nullptr)
+        return;
+
     if (d->worker == nullptr) {
         delete d;
+        d = nullptr;
         return;
     }
 
@@ -353,6 +357,7 @@ void AmdSmiDataSource::end()
         delete gpu;
 
     delete d;
+    d = nullptr;
 }
 
 

--- a/rpd_tracer/DataSource.h
+++ b/rpd_tracer/DataSource.h
@@ -28,7 +28,7 @@ namespace rpdtracer {
 class DataSource
 {
 public:
-    //DataSource();
+    virtual ~DataSource() = default;
     virtual void init() = 0;
     virtual void end() = 0;
     virtual void startTracing() = 0;

--- a/rpd_tracer/RocprofDataSource.cpp
+++ b/rpd_tracer/RocprofDataSource.cpp
@@ -242,6 +242,7 @@ public:
     static RocprofDataSourceShared& singleton();
 
     rocprofiler_client_id_t *clientId {nullptr};
+    rocprofiler_client_finalize_t finalizer {nullptr};
     rocprofiler_tool_configure_result_t cfg = rocprofiler_tool_configure_result_t{
                                             sizeof(rocprofiler_tool_configure_result_t),
                                             &RocprofDataSource::toolInit,
@@ -340,20 +341,28 @@ void RocprofDataSource::init()
     stopTracing();
 }
 
-void RocprofDataSource::end() 
+void RocprofDataSource::end()
 {
     flush();
+
+    if (s != nullptr && s->finalizer != nullptr && s->clientId != nullptr) {
+        s->finalizer(*s->clientId);
+        s->finalizer = nullptr;
+        s->clientId = nullptr;
+    }
 }
 
 void RocprofDataSource::startTracing()
 {
-    assert(s->contexts[d->id].handle != 0);
+    if (s->contexts[d->id].handle == 0)
+        return;
     rocprofiler_start_context(s->contexts[d->id]);
 }
 
 void RocprofDataSource::stopTracing()
 {
-    assert(s->contexts[d->id].handle != 0);
+    if (s->contexts[d->id].handle == 0)
+        return;
     rocprofiler_stop_context(s->contexts[d->id]);
 }
 
@@ -776,7 +785,8 @@ rocprofiler_configure(uint32_t                 version,
                       uint32_t                 priority,
                       rocprofiler_client_id_t* id)
 {
-    RocprofDataSourceShared::singleton();	// CRITICAL: static init
+    if (s == nullptr)
+        return nullptr;
 
     id->name = "rpd_tracer";
     s->clientId = id;
@@ -788,6 +798,8 @@ rocprofiler_configure(uint32_t                 version,
 
 int RocprofDataSource::toolInit(rocprofiler_client_finalize_t finialize_func, void* tool_data)
 {
+    s->finalizer = finialize_func;
+
     //s->name_info = common::get_buffer_tracing_names();
     s->name_info = rocprofiler::sdk::get_buffer_tracing_names();  // FIXME: decide
     //s->name_info = rocprofiler::sdk::get_callback_tracing_names();
@@ -928,19 +940,18 @@ int RocprofDataSource::toolInit(rocprofiler_client_finalize_t finialize_func, vo
 
 void RocprofDataSource::toolFinialize(void* tool_data)
 {
-    // This seems to happen pretty early.  So simulate a shutdown and disable context
-    //fprintf(stderr, "RocprofDataSource::toolFinalize\n");
+    if (s == nullptr)
+        return;
 
-    //end();	// FIXME: singleton - figure out startup order and teardown order
-
-    // FIXME: kernel code objects are already being removed by this point
-    //        keeping names (only) around to remedy this
-
-    rocprofiler_stop_context(s->utilityContext);
-    s->utilityContext.handle = 0;    // save us from ourselves
+    if (s->utilityContext.handle != 0) {
+        rocprofiler_stop_context(s->utilityContext);
+        s->utilityContext.handle = 0;
+    }
     for (auto &context : s->contexts) {
-        rocprofiler_stop_context(context);
-        context.handle = 0;
+        if (context.handle != 0) {
+            rocprofiler_stop_context(context);
+            context.handle = 0;
+        }
     }
 }
 


### PR DESCRIPTION
Rocprofiler-sdk was causing seg faults on shutdown.
Improve shutdown ordering
Manually call finalizer
Defend against unusual shutdown ordering